### PR TITLE
feat: add automated dhedge nav dashboard pipeline

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,59 @@
+name: Daily Data Update
+
+on:
+  schedule:
+    - cron: '20 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  daily:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: node dist/export_token_price_daily.js
+      - run: node dist/fetch_btc_daily.js
+      - run: node dist/build_nav_btc_daily.js
+      - name: Commit and push CSV updates
+        run: |
+          if git status --porcelain data | grep .; then
+            git config user.name "data-bot"
+            git config user.email "bot@users.noreply.github.com"
+            git add data/*.csv
+            git commit -m "daily update"
+            git push
+          else
+            echo "No CSV changes detected"
+          fi
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p pages
+          cp -r public/* pages/
+          mkdir -p pages/data
+          cp data/*.csv pages/data/
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages
+  deploy:
+    needs: daily
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -1,0 +1,34 @@
+name: Hourly Data Update
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  hourly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: node dist/export_token_price_hourly.js
+      - run: node dist/fetch_btc_hourly.js
+      - run: node dist/build_nav_btc_hourly.js
+      - name: Commit and push CSV updates
+        run: |
+          if git status --porcelain data | grep .; then
+            git config user.name "data-bot"
+            git config user.email "bot@users.noreply.github.com"
+            git add data/*.csv
+            git commit -m "hourly update"
+            git push
+          else
+            echo "No CSV changes detected"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.cache/
+pages/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,120 @@
-# VLHXBTC-dashboard
-Dashbord revenue for Valhalla BTC dehedge vault
+# dHEDGE NAV vs BTC Dashboard
+
+Automated data exporter and static dashboard that tracks the dHEDGE vault token price on Arbitrum and benchmarks performance against Bitcoin. The project collects on-chain NAV per share data, fetches BTC/USD prices from CoinGecko, derives comparison metrics, and publishes CSV datasets alongside a GitHub Pages dashboard with rich charts.
+
+## Features
+
+- Hourly and daily collection of the vault NAV per share (`tokenPrice()` on the PoolLogic contract).
+- Hourly (90 days) and daily (full history) BTC/USD prices from CoinGecko with ETag-aware caching.
+- Derived NAV vs BTC analytics (ROI in BTC, ROI in USD, alpha vs BTC) exported as CSV.
+- Production-ready GitHub Actions that backfill data, append new rows, commit updates, and deploy GitHub Pages.
+- Lightweight static dashboard (ECharts) with preset time range filters (1D/1W/1M/3M/YTD/ALL) that reads CSVs directly from the repository.
+- Robust error handling, exponential backoff for HTTP requests, RPC fallbacks, and data sanity checks.
+
+## Getting Started
+
+### Requirements
+
+- Node.js 20+
+- npm 9+
+
+### Installation
+
+```bash
+npm install
+```
+
+### Local Data Export
+
+Run the daily and hourly jobs locally. The first run backfills 365 days of NAV data and 72 hours of hourly NAV data.
+
+```bash
+# Build TypeScript -> dist/
+npm run build
+
+# Run daily collectors (NAV, BTC, derived metrics)
+npm run daily
+
+# Run hourly collectors (NAV, BTC, derived metrics)
+npm run hourly
+```
+
+CSV outputs are written into the `data/` directory:
+
+- `data/nav_tokenprice_usd_daily.csv` — `day,token_price_usd`
+- `data/nav_tokenprice_usd_hourly.csv` — `ts,token_price_usd`
+- `data/btc_usd_daily.csv` — `day,btc_usd`
+- `data/btc_usd_hourly.csv` — `ts,btc_usd`
+- `data/nav_btc_daily.csv` — `day,nav_usd,btc_usd,nav_btc,roi_in_btc,roi_in_usd,alpha_vs_btc`
+- `data/nav_btc_hourly.csv` — `ts,nav_usd,btc_usd,nav_btc,roi_in_btc,roi_in_usd,alpha_vs_btc`
+
+All CSV helpers guarantee sorted rows, unique keys, and a trailing newline.
+
+### Environment Configuration
+
+By default the exporter uses the public Arbitrum RPC. Override or add fallbacks with environment variables:
+
+```bash
+export ARBITRUM_RPC="https://arb1.arbitrum.io/rpc"
+export ARBITRUM_RPC_FALLBACKS="https://arb1.arbitrum.io/rpc,https://arb-mainnet.g.alchemy.com/v2/demo"
+```
+
+Create a `.env` or add these variables in GitHub Secrets to use premium endpoints.
+
+## GitHub Actions
+
+Two workflows live under `.github/workflows/`:
+
+- `hourly.yml` — runs every hour (`0 * * * *`) and via manual dispatch. Executes hourly NAV + BTC fetchers and derived metric builder, then commits updated CSVs.
+- `daily.yml` — runs daily at 23:20 UTC and via manual dispatch. Executes daily NAV + BTC fetchers, builds daily metrics, commits CSVs, and deploys GitHub Pages with the dashboard.
+
+Both workflows configure `user.name`/`user.email`, only commit when data changes, and push to `main`.
+
+## Dashboard
+
+The static dashboard is served from `public/` and deployed to GitHub Pages.
+
+To preview locally:
+
+```bash
+npm run build
+npm run serve
+# open http://localhost:8080
+```
+
+The dashboard loads CSVs from the repository using raw GitHub URLs. When hosted on GitHub Pages (e.g., `https://<owner>.github.io/<repo>/`), it automatically infers the repo owner/name. For alternative hosting, add `github-owner` and `github-repo` meta values or pass `?owner=<owner>&repo=<repo>` in the query string.
+
+### Chart Controls & Cards
+
+- **Time ranges** — 1D/1W use hourly data; longer ranges use daily data.
+- **Summary cards** — show the latest ROI in BTC, alpha vs BTC, and NAV denominated in BTC.
+- **Auto refresh** — refreshes data every 10 minutes.
+
+Adjust chart copy, colors, or fonts by editing `public/index.html` and `public/dashboard.js`.
+
+## Data Sources & Caveats
+
+- On-chain NAV: PoolLogic contract `tokenPrice()` on Arbitrum One (`0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9`). Binary search selects the block at each hour/day cutoff.
+- BTC/USD: CoinGecko `market_chart` API with ETag caching to minimize rate limits.
+- Sanity checks reject NAV points deviating more than ±10% from recent medians and fall back to additional RPCs when available.
+- All timestamps are UTC.
+
+## Customization
+
+- **PoolLogic address** — update the `POOL_LOGIC_ADDRESS` constant in `src/config.ts`.
+- **RPC endpoints** — set `ARBITRUM_RPC` / `ARBITRUM_RPC_FALLBACKS` env vars.
+- **Chart branding** — tweak typography/colors in `public/index.html` and `public/dashboard.js`.
+
+## Repository Structure
+
+```
+├── data/                   # CSV artifacts committed to the repo
+├── public/                 # Static dashboard deployed to GitHub Pages
+├── src/                    # TypeScript source for exporters and builders
+├── dist/                   # Compiled JS (ignored until `npm run build`)
+└── .github/workflows/      # GitHub Actions for hourly & daily automation
+```
+
+## License
+
+MIT

--- a/data/btc_usd_daily.csv
+++ b/data/btc_usd_daily.csv
@@ -1,0 +1,1 @@
+day,btc_usd

--- a/data/btc_usd_hourly.csv
+++ b/data/btc_usd_hourly.csv
@@ -1,0 +1,1 @@
+ts,btc_usd

--- a/data/nav_btc_daily.csv
+++ b/data/nav_btc_daily.csv
@@ -1,0 +1,1 @@
+day,nav_usd,btc_usd,nav_btc,roi_in_btc,roi_in_usd,alpha_vs_btc

--- a/data/nav_btc_hourly.csv
+++ b/data/nav_btc_hourly.csv
@@ -1,0 +1,1 @@
+ts,nav_usd,btc_usd,nav_btc,roi_in_btc,roi_in_usd,alpha_vs_btc

--- a/data/nav_tokenprice_usd_daily.csv
+++ b/data/nav_tokenprice_usd_daily.csv
@@ -1,0 +1,1 @@
+day,token_price_usd

--- a/data/nav_tokenprice_usd_hourly.csv
+++ b/data/nav_tokenprice_usd_hourly.csv
@@ -1,0 +1,1 @@
+ts,token_price_usd

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,156 @@
+{
+  "name": "vlxhbtc-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vlxhbtc-dashboard",
+      "version": "1.0.0",
+      "dependencies": {
+        "ethers": "^6.11.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vlxhbtc-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "daily": "npm run build && node dist/export_token_price_daily.js && node dist/fetch_btc_daily.js && node dist/build_nav_btc_daily.js",
+    "hourly": "npm run build && node dist/export_token_price_hourly.js && node dist/fetch_btc_hourly.js && node dist/build_nav_btc_hourly.js",
+    "serve": "npx http-server public"
+  },
+  "dependencies": {
+    "ethers": "^6.11.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.5"
+  }
+}

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,267 @@
+const RANGE_CONFIG = {
+  '1D': { days: 1, dataset: 'hourly' },
+  '1W': { days: 7, dataset: 'hourly' },
+  '1M': { days: 30, dataset: 'daily' },
+  '3M': { days: 90, dataset: 'daily' },
+  YTD: { dataset: 'daily', ytd: true },
+  ALL: { dataset: 'daily', all: true },
+};
+
+const state = {
+  daily: [],
+  hourly: [],
+  range: '1D',
+  charts: {},
+};
+
+function getMetaContent(name) {
+  const el = document.querySelector(`meta[name="${name}"]`);
+  return el ? el.content.trim() : '';
+}
+
+function detectRepo() {
+  const ownerParam = new URLSearchParams(window.location.search).get('owner');
+  const repoParam = new URLSearchParams(window.location.search).get('repo');
+  const ownerMeta = getMetaContent('github-owner');
+  const repoMeta = getMetaContent('github-repo');
+  if (ownerParam && repoParam) {
+    return { owner: ownerParam, repo: repoParam };
+  }
+  if (ownerMeta && repoMeta) {
+    return { owner: ownerMeta, repo: repoMeta };
+  }
+  const host = window.location.hostname;
+  if (host.endsWith('.github.io')) {
+    const owner = host.replace('.github.io', '');
+    const pathParts = window.location.pathname.split('/').filter(Boolean);
+    if (pathParts.length > 0) {
+      return { owner, repo: pathParts[0] };
+    }
+  }
+  return null;
+}
+
+function resolveCsvUrl(pathOrUrl) {
+  if (!pathOrUrl) return '';
+  if (/^https?:/i.test(pathOrUrl)) {
+    return pathOrUrl;
+  }
+  const repo = detectRepo();
+  if (!repo) {
+    return pathOrUrl;
+  }
+  const path = pathOrUrl.replace(/^\//, '');
+  return `https://raw.githubusercontent.com/${repo.owner}/${repo.repo}/main/${path}`;
+}
+
+async function fetchCsv(pathOrUrl) {
+  const url = resolveCsvUrl(pathOrUrl);
+  const res = await fetch(url, { cache: 'no-cache' });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.text();
+}
+
+function parseCsv(text) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length <= 1) {
+    return [];
+  }
+  const header = lines[0].split(',').map((h) => h.trim());
+  const rows = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const values = lines[i].split(',');
+    const row = {};
+    header.forEach((key, idx) => {
+      row[key] = values[idx];
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function toDailyData(rows) {
+  return rows.map((row) => ({
+    date: new Date(`${row.day}T00:00:00Z`),
+    nav_btc: Number(row.nav_btc),
+    roi_in_btc: Number(row.roi_in_btc) * 100,
+    roi_in_usd: Number(row.roi_in_usd) * 100,
+    alpha_vs_btc: Number(row.alpha_vs_btc) * 100,
+  }));
+}
+
+function toHourlyData(rows) {
+  return rows.map((row) => ({
+    date: new Date(row.ts),
+    nav_btc: Number(row.nav_btc),
+    roi_in_btc: Number(row.roi_in_btc) * 100,
+    roi_in_usd: Number(row.roi_in_usd) * 100,
+    alpha_vs_btc: Number(row.alpha_vs_btc) * 100,
+  }));
+}
+
+function filterData(rangeKey) {
+  const config = RANGE_CONFIG[rangeKey] || RANGE_CONFIG['ALL'];
+  const now = new Date();
+  let dataset = state.daily;
+  if (config.dataset === 'hourly') {
+    dataset = state.hourly.length > 0 ? state.hourly : state.daily;
+  }
+  if (config.all || dataset.length === 0) {
+    return dataset;
+  }
+  if (config.ytd) {
+    const start = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+    return dataset.filter((row) => row.date >= start);
+  }
+  if (config.days) {
+    const start = new Date(now.getTime() - config.days * 24 * 60 * 60 * 1000);
+    return dataset.filter((row) => row.date >= start);
+  }
+  return dataset;
+}
+
+function formatPercent(value) {
+  if (!Number.isFinite(value)) {
+    return '--';
+  }
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+function formatBtc(value) {
+  if (!Number.isFinite(value)) {
+    return '--';
+  }
+  return `${value.toFixed(8)} BTC`;
+}
+
+function updateCards() {
+  const source = state.daily.length > 0 ? state.daily : state.hourly;
+  if (source.length === 0) {
+    return;
+  }
+  const latest = source[source.length - 1];
+  document.getElementById('roi-btc').textContent = formatPercent(latest.roi_in_btc);
+  document.getElementById('alpha-btc').textContent = formatPercent(latest.alpha_vs_btc);
+  document.getElementById('nav-btc').textContent = formatBtc(latest.nav_btc);
+}
+
+function initCharts() {
+  state.charts.roi = echarts.init(document.getElementById('chart-roi-btc'));
+  state.charts.alpha = echarts.init(document.getElementById('chart-alpha'));
+  state.charts.nav = echarts.init(document.getElementById('chart-nav'));
+  window.addEventListener('resize', () => {
+    Object.values(state.charts).forEach((chart) => chart.resize());
+  });
+}
+
+function chartOptions(title, dataKey, data) {
+  const seriesData = data.map((row) => [row.date.getTime(), row[dataKey]]);
+  const isPercent = dataKey !== 'nav_btc';
+  return {
+    tooltip: {
+      trigger: 'axis',
+      valueFormatter: (value) =>
+        isPercent ? `${value >= 0 ? '+' : ''}${Number(value).toFixed(2)}%` : `${Number(value).toFixed(8)} BTC`,
+    },
+    xAxis: {
+      type: 'time',
+      axisLabel: {
+        color: '#94a3b8',
+      },
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: {
+        color: '#94a3b8',
+        formatter: (value) => (isPercent ? `${value.toFixed(0)}%` : value.toFixed(4)),
+      },
+      splitLine: {
+        lineStyle: {
+          color: 'rgba(148, 163, 184, 0.2)',
+        },
+      },
+    },
+    grid: {
+      left: 40,
+      right: 16,
+      top: 20,
+      bottom: 40,
+    },
+    series: [
+      {
+        type: 'line',
+        smooth: true,
+        showSymbol: false,
+        data: seriesData,
+        lineStyle: {
+          width: 2,
+        },
+        areaStyle: {
+          opacity: 0.08,
+        },
+      },
+    ],
+    textStyle: {
+      color: '#e2e8f0',
+    },
+    backgroundColor: 'transparent',
+  };
+}
+
+function updateCharts(rangeKey) {
+  const filtered = filterData(rangeKey);
+  Object.entries({
+    roi: 'roi_in_btc',
+    alpha: 'alpha_vs_btc',
+    nav: 'nav_btc',
+  }).forEach(([chartKey, dataKey]) => {
+    const chart = state.charts[chartKey];
+    if (!chart) return;
+    if (filtered.length === 0) {
+      chart.clear();
+      return;
+    }
+    chart.setOption(chartOptions(chartKey, dataKey, filtered));
+  });
+}
+
+async function loadData() {
+  const dailyPath = getMetaContent('data-nav-daily');
+  const hourlyPath = getMetaContent('data-nav-hourly');
+  try {
+    const [dailyText, hourlyText] = await Promise.all([
+      fetchCsv(dailyPath),
+      fetchCsv(hourlyPath),
+    ]);
+    state.daily = toDailyData(parseCsv(dailyText));
+    state.hourly = toHourlyData(parseCsv(hourlyText));
+    updateCards();
+    updateCharts(state.range);
+  } catch (error) {
+    console.error('Failed to load dashboard data', error);
+  }
+}
+
+function initFilters() {
+  document.querySelectorAll('.filters button').forEach((button) => {
+    button.addEventListener('click', () => {
+      const range = button.dataset.range;
+      state.range = range;
+      document.querySelectorAll('.filters button').forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+      updateCharts(range);
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initCharts();
+  initFilters();
+  loadData();
+  setInterval(loadData, 10 * 60 * 1000);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>dHEDGE Vault NAV vs BTC Dashboard</title>
+    <meta name="data-nav-daily" content="data/nav_btc_daily.csv" />
+    <meta name="data-nav-hourly" content="data/nav_btc_hourly.csv" />
+    <meta name="github-owner" content="" />
+    <meta name="github-repo" content="" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+      body {
+        margin: 0;
+        padding: 24px;
+        min-height: 100vh;
+        background: linear-gradient(180deg, rgba(15, 23, 42, 1) 0%, rgba(15, 23, 42, 0.85) 100%);
+      }
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 2rem;
+        font-weight: 600;
+      }
+      p.description {
+        margin: 0;
+        max-width: 640px;
+        color: #94a3b8;
+      }
+      .filters {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .filters button {
+        padding: 6px 12px;
+        border: 1px solid #334155;
+        border-radius: 999px;
+        background: rgba(51, 65, 85, 0.4);
+        color: inherit;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+      .filters button:hover {
+        background: rgba(59, 130, 246, 0.25);
+        transform: translateY(-1px);
+      }
+      .filters button.active {
+        background: #38bdf8;
+        color: #0f172a;
+        border-color: transparent;
+        font-weight: 600;
+      }
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .card {
+        padding: 16px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.8);
+        border: 1px solid rgba(148, 163, 184, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .card span.label {
+        font-size: 0.875rem;
+        color: #94a3b8;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .card span.value {
+        font-size: 1.75rem;
+        font-weight: 600;
+      }
+      .chart-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 16px;
+      }
+      .chart {
+        height: 320px;
+        background: rgba(15, 23, 42, 0.8);
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.1);
+        padding: 16px;
+      }
+      .chart h2 {
+        margin: 0 0 12px;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+      .chart-container {
+        width: 100%;
+        height: calc(100% - 24px);
+      }
+      footer {
+        margin-top: 32px;
+        font-size: 0.75rem;
+        color: #64748b;
+      }
+      a {
+        color: #38bdf8;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
+    <script src="dashboard.js" defer></script>
+  </head>
+  <body>
+    <header>
+      <h1>dHEDGE Vault NAV vs BTC</h1>
+      <p class="description">
+        Hourly and daily net asset value per share (USD) for the dHEDGE vault at
+        0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9, benchmarked against Bitcoin (BTC/USD).
+        Data refreshes automatically every 10 minutes.
+      </p>
+      <div class="filters" role="group" aria-label="Select time range">
+        <button data-range="1D" class="active">1D</button>
+        <button data-range="1W">1W</button>
+        <button data-range="1M">1M</button>
+        <button data-range="3M">3M</button>
+        <button data-range="YTD">YTD</button>
+        <button data-range="ALL">ALL</button>
+      </div>
+    </header>
+    <section class="cards">
+      <div class="card" aria-live="polite">
+        <span class="label">ROI in BTC</span>
+        <span class="value" id="roi-btc">--</span>
+      </div>
+      <div class="card" aria-live="polite">
+        <span class="label">Alpha vs BTC</span>
+        <span class="value" id="alpha-btc">--</span>
+      </div>
+      <div class="card" aria-live="polite">
+        <span class="label">NAV in BTC</span>
+        <span class="value" id="nav-btc">--</span>
+      </div>
+    </section>
+    <section class="chart-grid">
+      <div class="chart">
+        <h2>ROI in BTC (%)</h2>
+        <div id="chart-roi-btc" class="chart-container"></div>
+      </div>
+      <div class="chart">
+        <h2>Alpha vs BTC (%)</h2>
+        <div id="chart-alpha" class="chart-container"></div>
+      </div>
+      <div class="chart">
+        <h2>NAV per Share (BTC)</h2>
+        <div id="chart-nav" class="chart-container"></div>
+      </div>
+    </section>
+    <footer>
+      Built with public data from CoinGecko and Arbitrum. Charts powered by ECharts. Updates every
+      hour and day via GitHub Actions.
+    </footer>
+  </body>
+</html>

--- a/src/build_nav_btc_daily.ts
+++ b/src/build_nav_btc_daily.ts
@@ -1,0 +1,78 @@
+import {
+  DAILY_BTC_CSV,
+  DAILY_NAV_BTC_CSV,
+  DAILY_NAV_CSV,
+} from './config.js';
+import { readCSV, writeCSV } from './utils/csv.js';
+import { logger } from './utils/log.js';
+
+interface CombinedRow {
+  day: string;
+  nav_usd: number;
+  btc_usd: number;
+}
+
+function parseRows(): CombinedRow[] {
+  const navRows = readCSV(DAILY_NAV_CSV).rows;
+  const btcRows = readCSV(DAILY_BTC_CSV).rows;
+  const btcMap = new Map<string, number>();
+  for (const row of btcRows) {
+    const value = Number(row.btc_usd);
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+    btcMap.set(row.day, value);
+  }
+  const combined: CombinedRow[] = [];
+  for (const row of navRows) {
+    const nav = Number(row.token_price_usd);
+    const btc = btcMap.get(row.day);
+    if (!Number.isFinite(nav) || btc === undefined || !Number.isFinite(btc)) {
+      continue;
+    }
+    combined.push({ day: row.day, nav_usd: nav, btc_usd: btc });
+  }
+  combined.sort((a, b) => (a.day > b.day ? 1 : a.day < b.day ? -1 : 0));
+  return combined;
+}
+
+function formatNumber(value: number, decimals: number): string {
+  return value.toFixed(decimals);
+}
+
+async function main(): Promise<void> {
+  const combined = parseRows();
+  if (combined.length === 0) {
+    logger.warn('No overlapping daily NAV/BTC data found.');
+    return;
+  }
+  const nav0 = combined[0].nav_usd;
+  const btc0 = combined[0].btc_usd;
+  const navBtc0 = combined[0].nav_usd / combined[0].btc_usd;
+  const rows = combined.map((row) => {
+    const navBtc = row.nav_usd / row.btc_usd;
+    const roiBtc = navBtc0 === 0 ? 0 : navBtc / navBtc0 - 1;
+    const roiUsd = nav0 === 0 ? 0 : row.nav_usd / nav0 - 1;
+    const alpha = btc0 === 0 ? 0 : (roiUsd + 1) / (row.btc_usd / btc0) - 1;
+    return {
+      day: row.day,
+      nav_usd: formatNumber(row.nav_usd, 8),
+      btc_usd: formatNumber(row.btc_usd, 2),
+      nav_btc: formatNumber(navBtc, 8),
+      roi_in_btc: formatNumber(roiBtc, 6),
+      roi_in_usd: formatNumber(roiUsd, 6),
+      alpha_vs_btc: formatNumber(alpha, 6),
+    };
+  });
+  writeCSV(
+    DAILY_NAV_BTC_CSV,
+    ['day', 'nav_usd', 'btc_usd', 'nav_btc', 'roi_in_btc', 'roi_in_usd', 'alpha_vs_btc'],
+    rows,
+  );
+  logger.info(`Built ${rows.length} daily NAV vs BTC rows.`);
+}
+
+main().catch((error) => {
+  logger.error(`build_nav_btc_daily failed: ${(error as Error).stack ?? (error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/build_nav_btc_hourly.ts
+++ b/src/build_nav_btc_hourly.ts
@@ -1,0 +1,78 @@
+import {
+  HOURLY_BTC_CSV,
+  HOURLY_NAV_BTC_CSV,
+  HOURLY_NAV_CSV,
+} from './config.js';
+import { readCSV, writeCSV } from './utils/csv.js';
+import { logger } from './utils/log.js';
+
+interface CombinedRow {
+  ts: string;
+  nav_usd: number;
+  btc_usd: number;
+}
+
+function parseRows(): CombinedRow[] {
+  const navRows = readCSV(HOURLY_NAV_CSV).rows;
+  const btcRows = readCSV(HOURLY_BTC_CSV).rows;
+  const btcMap = new Map<string, number>();
+  for (const row of btcRows) {
+    const value = Number(row.btc_usd);
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+    btcMap.set(row.ts, value);
+  }
+  const combined: CombinedRow[] = [];
+  for (const row of navRows) {
+    const nav = Number(row.token_price_usd);
+    const btc = btcMap.get(row.ts);
+    if (!Number.isFinite(nav) || btc === undefined || !Number.isFinite(btc)) {
+      continue;
+    }
+    combined.push({ ts: row.ts, nav_usd: nav, btc_usd: btc });
+  }
+  combined.sort((a, b) => (a.ts > b.ts ? 1 : a.ts < b.ts ? -1 : 0));
+  return combined;
+}
+
+function formatNumber(value: number, decimals: number): string {
+  return value.toFixed(decimals);
+}
+
+async function main(): Promise<void> {
+  const combined = parseRows();
+  if (combined.length === 0) {
+    logger.warn('No overlapping hourly NAV/BTC data found.');
+    return;
+  }
+  const nav0 = combined[0].nav_usd;
+  const btc0 = combined[0].btc_usd;
+  const navBtc0 = combined[0].nav_usd / combined[0].btc_usd;
+  const rows = combined.map((row) => {
+    const navBtc = row.nav_usd / row.btc_usd;
+    const roiBtc = navBtc0 === 0 ? 0 : navBtc / navBtc0 - 1;
+    const roiUsd = nav0 === 0 ? 0 : row.nav_usd / nav0 - 1;
+    const alpha = btc0 === 0 ? 0 : (roiUsd + 1) / (row.btc_usd / btc0) - 1;
+    return {
+      ts: row.ts,
+      nav_usd: formatNumber(row.nav_usd, 8),
+      btc_usd: formatNumber(row.btc_usd, 2),
+      nav_btc: formatNumber(navBtc, 8),
+      roi_in_btc: formatNumber(roiBtc, 6),
+      roi_in_usd: formatNumber(roiUsd, 6),
+      alpha_vs_btc: formatNumber(alpha, 6),
+    };
+  });
+  writeCSV(
+    HOURLY_NAV_BTC_CSV,
+    ['ts', 'nav_usd', 'btc_usd', 'nav_btc', 'roi_in_btc', 'roi_in_usd', 'alpha_vs_btc'],
+    rows,
+  );
+  logger.info(`Built ${rows.length} hourly NAV vs BTC rows.`);
+}
+
+main().catch((error) => {
+  logger.error(`build_nav_btc_hourly failed: ${(error as Error).stack ?? (error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+export const POOL_LOGIC_ADDRESS = '0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9';
+export const ARBITRUM_RPC = process.env.ARBITRUM_RPC ?? 'https://arb1.arbitrum.io/rpc';
+export const ARBITRUM_RPC_FALLBACKS = (process.env.ARBITRUM_RPC_FALLBACKS ?? '')
+  .split(',')
+  .map((url) => url.trim())
+  .filter((url) => url.length > 0);
+
+export const DAILY_NAV_CSV = 'data/nav_tokenprice_usd_daily.csv';
+export const HOURLY_NAV_CSV = 'data/nav_tokenprice_usd_hourly.csv';
+export const DAILY_BTC_CSV = 'data/btc_usd_daily.csv';
+export const HOURLY_BTC_CSV = 'data/btc_usd_hourly.csv';
+export const DAILY_NAV_BTC_CSV = 'data/nav_btc_daily.csv';
+export const HOURLY_NAV_BTC_CSV = 'data/nav_btc_hourly.csv';

--- a/src/export_token_price_daily.ts
+++ b/src/export_token_price_daily.ts
@@ -1,0 +1,152 @@
+import { Contract, JsonRpcProvider, formatUnits } from 'ethers';
+import {
+  DAILY_NAV_CSV,
+  POOL_LOGIC_ADDRESS,
+} from './config.js';
+import { blockAtEndOfDayUTC } from './utils/arb.js';
+import { upsertRows, readCSV, type CSVRow } from './utils/csv.js';
+import { logger } from './utils/log.js';
+import { buildProviderSequence } from './utils/provider.js';
+
+const ABI = ['function tokenPrice() view returns (uint256)'];
+const MAX_BACKFILL_DAYS = 365;
+const SANITY_TOLERANCE = 0.1; // 10%
+
+interface DayPrice extends CSVRow {
+  day: string;
+  token_price_usd: string;
+}
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function parseDay(day: string): Date {
+  return new Date(`${day}T00:00:00Z`);
+}
+
+function addDays(date: Date, days: number): Date {
+  const copy = new Date(date.getTime());
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+function passesSanityCheck(history: DayPrice[], candidate: DayPrice): boolean {
+  const priorValues = history
+    .filter((row) => row.day < candidate.day)
+    .slice(-7)
+    .map((row) => Number(row.token_price_usd));
+  if (priorValues.length < 3) {
+    return true;
+  }
+  const med = median(priorValues);
+  if (med === 0) {
+    return true;
+  }
+  const value = Number(candidate.token_price_usd);
+  const deviation = Math.abs(value - med) / med;
+  return deviation <= SANITY_TOLERANCE;
+}
+
+function determineDaysToFetch(existing: DayPrice[]): string[] {
+  const existingSet = new Set(existing.map((row) => row.day));
+  const now = new Date();
+  const endDate = addDays(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())), -1);
+  if (endDate.getTime() < 0) {
+    return [];
+  }
+  let startDate: Date;
+  if (existing.length === 0) {
+    startDate = addDays(endDate, -MAX_BACKFILL_DAYS + 1);
+  } else {
+    const lastDay = existing[existing.length - 1].day;
+    startDate = addDays(parseDay(lastDay), 1);
+  }
+  const days: string[] = [];
+  for (let d = new Date(startDate.getTime()); d <= endDate; d = addDays(d, 1)) {
+    const day = isoDay(d);
+    if (!existingSet.has(day)) {
+      days.push(day);
+    }
+  }
+  return days;
+}
+
+async function fetchTokenPrice(
+  provider: JsonRpcProvider,
+  contract: Contract,
+  day: string,
+): Promise<number> {
+  const block = await blockAtEndOfDayUTC(provider, parseDay(day));
+  const price = await contract.tokenPrice({ blockTag: block });
+  const numeric = Number(formatUnits(price, 18));
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`Invalid token price ${numeric} for ${day}`);
+  }
+  return numeric;
+}
+
+async function main(): Promise<void> {
+  const table = readCSV(DAILY_NAV_CSV);
+  const existing = table.rows.map((row) => ({
+    day: row.day,
+    token_price_usd: row.token_price_usd,
+  })) as DayPrice[];
+  existing.sort((a, b) => (a.day > b.day ? 1 : a.day < b.day ? -1 : 0));
+  const targets = determineDaysToFetch(existing);
+  if (targets.length === 0) {
+    logger.info('No new daily token price data needed.');
+    return;
+  }
+  const providers = buildProviderSequence();
+  const contracts = providers.map((provider) => new Contract(POOL_LOGIC_ADDRESS, ABI, provider));
+  const history = [...existing];
+  const newRows: DayPrice[] = [];
+  for (const day of targets) {
+    let fetched: number | null = null;
+    for (let i = 0; i < providers.length; i += 1) {
+      try {
+        const value = await fetchTokenPrice(providers[i], contracts[i], day);
+        const candidate: DayPrice = { day, token_price_usd: value.toFixed(8) };
+        if (!passesSanityCheck([...history, ...newRows], candidate)) {
+          throw new Error('Sanity check failed (>10% deviation from rolling median)');
+        }
+        fetched = value;
+        newRows.push(candidate);
+        history.push(candidate);
+        logger.info(`Fetched NAV ${value.toFixed(8)} for ${day} using provider ${i + 1}`);
+        break;
+      } catch (error) {
+        logger.warn(
+          `Failed to fetch NAV for ${day} using provider ${i + 1}: ${(error as Error).message}`,
+        );
+      }
+    }
+    if (fetched === null) {
+      logger.error(`All providers failed for day ${day}, skipping.`);
+    }
+  }
+  if (newRows.length === 0) {
+    logger.warn('No valid NAV rows fetched.');
+    return;
+  }
+  upsertRows(DAILY_NAV_CSV, ['day', 'token_price_usd'], 'day', newRows);
+  logger.info(`Appended ${newRows.length} daily NAV rows.`);
+}
+
+main().catch((error) => {
+  logger.error(`export_token_price_daily failed: ${(error as Error).stack ?? (error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/export_token_price_hourly.ts
+++ b/src/export_token_price_hourly.ts
@@ -1,0 +1,161 @@
+import { Contract, JsonRpcProvider, formatUnits } from 'ethers';
+import { HOURLY_NAV_CSV, POOL_LOGIC_ADDRESS } from './config.js';
+import { blockAtEndOfHourUTC } from './utils/arb.js';
+import { readCSV, upsertRows, type CSVRow } from './utils/csv.js';
+import { logger } from './utils/log.js';
+import { buildProviderSequence } from './utils/provider.js';
+
+const ABI = ['function tokenPrice() view returns (uint256)'];
+const MAX_BACKFILL_HOURS = 72;
+const SANITY_TOLERANCE = 0.1;
+
+interface HourPrice extends CSVRow {
+  ts: string;
+  token_price_usd: string;
+}
+
+function startOfHour(date: Date): Date {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      0,
+      0,
+    ),
+  );
+}
+
+function addHours(date: Date, hours: number): Date {
+  const copy = new Date(date.getTime());
+  copy.setUTCHours(copy.getUTCHours() + hours);
+  return copy;
+}
+
+function isoHour(date: Date): string {
+  return `${date.toISOString().slice(0, 13)}:00:00Z`;
+}
+
+function parseHour(ts: string): Date {
+  return new Date(ts);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+function passesSanityCheck(history: HourPrice[], candidate: HourPrice): boolean {
+  const priorValues = history
+    .filter((row) => row.ts < candidate.ts)
+    .slice(-24)
+    .map((row) => Number(row.token_price_usd));
+  if (priorValues.length < 6) {
+    return true;
+  }
+  const med = median(priorValues);
+  if (med === 0) {
+    return true;
+  }
+  const value = Number(candidate.token_price_usd);
+  const deviation = Math.abs(value - med) / med;
+  return deviation <= SANITY_TOLERANCE;
+}
+
+function determineHoursToFetch(existing: HourPrice[]): string[] {
+  const existingSet = new Set(existing.map((row) => row.ts));
+  const now = new Date();
+  const endHour = addHours(startOfHour(now), -1);
+  let startHour: Date;
+  if (existing.length === 0) {
+    startHour = addHours(endHour, -MAX_BACKFILL_HOURS + 1);
+  } else {
+    const lastTs = existing[existing.length - 1].ts;
+    startHour = addHours(parseHour(lastTs), 1);
+  }
+  const hours: string[] = [];
+  for (let cursor = new Date(startHour.getTime()); cursor <= endHour; cursor = addHours(cursor, 1)) {
+    const key = isoHour(cursor);
+    if (!existingSet.has(key)) {
+      hours.push(key);
+    }
+  }
+  return hours;
+}
+
+async function fetchTokenPrice(
+  provider: JsonRpcProvider,
+  contract: Contract,
+  ts: string,
+): Promise<number> {
+  const block = await blockAtEndOfHourUTC(provider, parseHour(ts));
+  const price = await contract.tokenPrice({ blockTag: block });
+  const numeric = Number(formatUnits(price, 18));
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`Invalid token price ${numeric} for ${ts}`);
+  }
+  return numeric;
+}
+
+async function main(): Promise<void> {
+  const table = readCSV(HOURLY_NAV_CSV);
+  const existing = table.rows.map((row) => ({
+    ts: row.ts,
+    token_price_usd: row.token_price_usd,
+  })) as HourPrice[];
+  existing.sort((a, b) => (a.ts > b.ts ? 1 : a.ts < b.ts ? -1 : 0));
+  const targets = determineHoursToFetch(existing);
+  if (targets.length === 0) {
+    logger.info('No new hourly token price data needed.');
+    return;
+  }
+  const providers = buildProviderSequence();
+  const contracts = providers.map((provider) => new Contract(POOL_LOGIC_ADDRESS, ABI, provider));
+  const history = [...existing];
+  const newRows: HourPrice[] = [];
+  for (const ts of targets) {
+    let fetched: number | null = null;
+    for (let i = 0; i < providers.length; i += 1) {
+      try {
+        const value = await fetchTokenPrice(providers[i], contracts[i], ts);
+        const candidate: HourPrice = { ts, token_price_usd: value.toFixed(8) };
+        if (!passesSanityCheck([...history, ...newRows], candidate)) {
+          throw new Error('Sanity check failed (>10% deviation from rolling median)');
+        }
+        fetched = value;
+        newRows.push(candidate);
+        history.push(candidate);
+        logger.info(`Fetched hourly NAV ${value.toFixed(8)} for ${ts} using provider ${i + 1}`);
+        break;
+      } catch (error) {
+        logger.warn(
+          `Failed to fetch hourly NAV for ${ts} using provider ${i + 1}: ${(error as Error).message}`,
+        );
+      }
+    }
+    if (fetched === null) {
+      logger.error(`All providers failed for hour ${ts}, skipping.`);
+    }
+  }
+  if (newRows.length === 0) {
+    logger.warn('No valid hourly NAV rows fetched.');
+    return;
+  }
+  upsertRows(HOURLY_NAV_CSV, ['ts', 'token_price_usd'], 'ts', newRows);
+  logger.info(`Appended ${newRows.length} hourly NAV rows.`);
+}
+
+main().catch((error) => {
+  logger.error(
+    `export_token_price_hourly failed: ${(error as Error).stack ?? (error as Error).message}`,
+  );
+  process.exitCode = 1;
+});

--- a/src/fetch_btc_daily.ts
+++ b/src/fetch_btc_daily.ts
@@ -1,0 +1,34 @@
+import { DAILY_BTC_CSV } from './config.js';
+import { fetchJson } from './utils/http.js';
+import { writeCSV } from './utils/csv.js';
+import { logger } from './utils/log.js';
+
+interface MarketChartResponse {
+  prices: [number, number][];
+}
+
+const URL =
+  'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=max&interval=daily';
+
+function isoDayFromMs(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+async function main(): Promise<void> {
+  const data = await fetchJson<MarketChartResponse>(URL, { etagCacheKey: 'btc-usd-daily' });
+  const map = new Map<string, number>();
+  for (const [ms, price] of data.prices) {
+    const day = isoDayFromMs(ms);
+    map.set(day, price);
+  }
+  const rows = Array.from(map.entries())
+    .map(([day, price]) => ({ day, btc_usd: price.toFixed(2) }))
+    .sort((a, b) => (a.day > b.day ? 1 : a.day < b.day ? -1 : 0));
+  writeCSV(DAILY_BTC_CSV, ['day', 'btc_usd'], rows);
+  logger.info(`Wrote ${rows.length} daily BTC price rows.`);
+}
+
+main().catch((error) => {
+  logger.error(`fetch_btc_daily failed: ${(error as Error).stack ?? (error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/fetch_btc_hourly.ts
+++ b/src/fetch_btc_hourly.ts
@@ -1,0 +1,36 @@
+import { HOURLY_BTC_CSV } from './config.js';
+import { fetchJson } from './utils/http.js';
+import { writeCSV } from './utils/csv.js';
+import { logger } from './utils/log.js';
+
+interface MarketChartResponse {
+  prices: [number, number][];
+}
+
+const URL =
+  'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=90&interval=hourly';
+
+function isoHourFromMs(ms: number): string {
+  const date = new Date(ms);
+  const hourIso = date.toISOString();
+  return `${hourIso.slice(0, 13)}:00:00Z`;
+}
+
+async function main(): Promise<void> {
+  const data = await fetchJson<MarketChartResponse>(URL, { etagCacheKey: 'btc-usd-hourly' });
+  const map = new Map<string, number>();
+  for (const [ms, price] of data.prices) {
+    const ts = isoHourFromMs(ms);
+    map.set(ts, price);
+  }
+  const rows = Array.from(map.entries())
+    .map(([ts, price]) => ({ ts, btc_usd: price.toFixed(2) }))
+    .sort((a, b) => (a.ts > b.ts ? 1 : a.ts < b.ts ? -1 : 0));
+  writeCSV(HOURLY_BTC_CSV, ['ts', 'btc_usd'], rows);
+  logger.info(`Wrote ${rows.length} hourly BTC price rows.`);
+}
+
+main().catch((error) => {
+  logger.error(`fetch_btc_hourly failed: ${(error as Error).stack ?? (error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/utils/arb.ts
+++ b/src/utils/arb.ts
@@ -1,0 +1,74 @@
+import { JsonRpcProvider, Block } from 'ethers';
+import { logger } from './log.js';
+
+async function getBlockSafe(provider: JsonRpcProvider, blockNumber: number): Promise<Block> {
+  const block = await provider.getBlock(blockNumber);
+  if (!block) {
+    throw new Error(`Block ${blockNumber} not found`);
+  }
+  return block;
+}
+
+async function latestBlock(provider: JsonRpcProvider): Promise<{ number: number; timestamp: number }> {
+  const number = await provider.getBlockNumber();
+  const block = await getBlockSafe(provider, number);
+  return { number, timestamp: block.timestamp };
+}
+
+async function findBlockAtOrBefore(provider: JsonRpcProvider, targetTimestamp: number): Promise<number> {
+  const { number: latestNumber, timestamp: latestTimestamp } = await latestBlock(provider);
+  if (targetTimestamp >= latestTimestamp) {
+    return latestNumber;
+  }
+  let low = 0;
+  let high = latestNumber;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const block = await getBlockSafe(provider, mid);
+    if (block.timestamp === targetTimestamp) {
+      return mid;
+    }
+    if (block.timestamp < targetTimestamp) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return Math.max(high, 0);
+}
+
+function endOfDayTimestamp(date: Date): number {
+  return Math.floor(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59) / 1000,
+  );
+}
+
+function endOfHourTimestamp(date: Date): number {
+  return Math.floor(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      59,
+      59,
+    ) / 1000,
+  );
+}
+
+export async function blockAtEndOfDayUTC(provider: JsonRpcProvider, date?: Date): Promise<number> {
+  const targetDate = date ?? new Date();
+  const target = endOfDayTimestamp(targetDate);
+  const blockNumber = await findBlockAtOrBefore(provider, target);
+  logger.info(`Resolved end-of-day block ${blockNumber} for ${targetDate.toISOString().slice(0, 10)}`);
+  return blockNumber;
+}
+
+export async function blockAtEndOfHourUTC(provider: JsonRpcProvider, date: Date): Promise<number> {
+  const target = endOfHourTimestamp(date);
+  const blockNumber = await findBlockAtOrBefore(provider, target);
+  logger.info(
+    `Resolved end-of-hour block ${blockNumber} for ${date.toISOString().slice(0, 13)}:00Z`,
+  );
+  return blockNumber;
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import { logger } from './log.js';
+
+export type CSVRow = Record<string, string>;
+
+export interface CSVTable {
+  header: string[];
+  rows: CSVRow[];
+}
+
+function ensureDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function parseLine(line: string, expectedColumns: number): string[] {
+  const values = line.split(',');
+  if (values.length !== expectedColumns) {
+    throw new Error(`Invalid CSV line column count: expected ${expectedColumns}, got ${values.length} (line: ${line})`);
+  }
+  return values.map((v) => v.trim());
+}
+
+export function parseCSV(content: string): CSVTable {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return { header: [], rows: [] };
+  }
+  const header = lines[0].split(',').map((h) => h.trim());
+  const rows: CSVRow[] = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const values = parseLine(lines[i], header.length);
+    const row: CSVRow = {};
+    header.forEach((col, idx) => {
+      row[col] = values[idx];
+    });
+    rows.push(row);
+  }
+  return { header, rows };
+}
+
+export function readCSV(filePath: string): CSVTable {
+  if (!fs.existsSync(filePath)) {
+    return { header: [], rows: [] };
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (content.trim().length === 0) {
+    return { header: [], rows: [] };
+  }
+  return parseCSV(content);
+}
+
+export function writeCSV(filePath: string, header: string[], rows: CSVRow[]): void {
+  ensureDir(filePath);
+  const headerLine = header.join(',');
+  const lines = [headerLine];
+  for (const row of rows) {
+    const values = header.map((col) => {
+      const value = row[col] ?? '';
+      if (value.includes(',') || value.includes('\n')) {
+        throw new Error(`CSV value contains unsupported characters: ${value}`);
+      }
+      return value;
+    });
+    lines.push(values.join(','));
+  }
+  const output = `${lines.join('\n')}\n`;
+  fs.writeFileSync(filePath, output, 'utf8');
+}
+
+export function upsertRows(
+  filePath: string,
+  header: string[],
+  keyColumn: string,
+  newRows: CSVRow[],
+  sortComparator?: (a: CSVRow, b: CSVRow) => number,
+): CSVRow[] {
+  const table = readCSV(filePath);
+  let effectiveHeader = header;
+  if (table.header.length > 0) {
+    effectiveHeader = table.header;
+    if (effectiveHeader.join(',') !== header.join(',')) {
+      logger.warn(`Header mismatch for ${filePath}, using existing header.`);
+    }
+  }
+  const map = new Map<string, CSVRow>();
+  for (const row of table.rows) {
+    const key = row[keyColumn];
+    if (!key) {
+      continue;
+    }
+    map.set(key, row);
+  }
+  for (const row of newRows) {
+    const key = row[keyColumn];
+    if (!key) {
+      throw new Error(`Missing key column ${keyColumn} in row ${JSON.stringify(row)}`);
+    }
+    map.set(key, { ...map.get(key), ...row });
+  }
+  const mergedRows = Array.from(map.values());
+  const comparator =
+    sortComparator ?? ((a: CSVRow, b: CSVRow) => (a[keyColumn] > b[keyColumn] ? 1 : a[keyColumn] < b[keyColumn] ? -1 : 0));
+  mergedRows.sort(comparator);
+  writeCSV(filePath, effectiveHeader, mergedRows);
+  return mergedRows;
+}

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,126 @@
+import fs from 'fs';
+import path from 'path';
+import { logger } from './log.js';
+
+const CACHE_DIR = path.resolve('.cache');
+const ETAG_FILE = path.join(CACHE_DIR, 'etags.json');
+const RESPONSE_DIR = path.join(CACHE_DIR, 'responses');
+
+interface FetchJsonOptions {
+  etagCacheKey?: string;
+  timeoutMs?: number;
+  retries?: number;
+}
+
+interface EtagStore {
+  [key: string]: string;
+}
+
+function ensureCache(): void {
+  if (!fs.existsSync(CACHE_DIR)) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(RESPONSE_DIR)) {
+    fs.mkdirSync(RESPONSE_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(ETAG_FILE)) {
+    fs.writeFileSync(ETAG_FILE, '{}', 'utf8');
+  }
+}
+
+function loadEtags(): EtagStore {
+  ensureCache();
+  try {
+    const raw = fs.readFileSync(ETAG_FILE, 'utf8');
+    return JSON.parse(raw) as EtagStore;
+  } catch (error) {
+    logger.warn(`Failed to read etag cache, resetting. ${(error as Error).message}`);
+    fs.writeFileSync(ETAG_FILE, '{}', 'utf8');
+    return {};
+  }
+}
+
+function saveEtags(store: EtagStore): void {
+  ensureCache();
+  fs.writeFileSync(ETAG_FILE, JSON.stringify(store, null, 2), 'utf8');
+}
+
+function responseCachePath(cacheKey: string): string {
+  return path.join(RESPONSE_DIR, `${cacheKey}.json`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function fetchJson<T>(url: string, options: FetchJsonOptions = {}): Promise<T> {
+  const { etagCacheKey, timeoutMs = 15000, retries = 5 } = options;
+  const etags = loadEtags();
+  const headers: Record<string, string> = {
+    'User-Agent': 'vlxhbtc-dashboard/1.0 (+https://github.com)'
+  };
+  if (etagCacheKey && etags[etagCacheKey]) {
+    headers['If-None-Match'] = etags[etagCacheKey];
+  }
+  let attempt = 0;
+  let backoff = 250;
+  let lastError: Error | undefined;
+  while (attempt < retries) {
+    attempt += 1;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      const res = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (res.status === 304) {
+        if (!etagCacheKey) {
+          throw new Error('Received 304 but no etag cache key provided');
+        }
+        const cachePath = responseCachePath(etagCacheKey);
+        if (!fs.existsSync(cachePath)) {
+          throw new Error(`ETag cache miss for ${etagCacheKey}`);
+        }
+        const cached = fs.readFileSync(cachePath, 'utf8');
+        return JSON.parse(cached) as T;
+      }
+      if (res.status === 429 || res.status >= 500) {
+        lastError = new Error(`HTTP ${res.status} ${res.statusText}`);
+        logger.warn(`Request to ${url} failed with ${res.status}. Retrying in ${backoff}ms...`);
+        await delay(backoff);
+        backoff *= 2;
+        continue;
+      }
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+      }
+      const text = await res.text();
+      const data = JSON.parse(text) as T;
+      if (etagCacheKey) {
+        const etag = res.headers.get('etag');
+        if (etag) {
+          etags[etagCacheKey] = etag;
+          saveEtags(etags);
+        }
+        const cachePath = responseCachePath(etagCacheKey);
+        fs.writeFileSync(cachePath, text, 'utf8');
+      }
+      return data;
+    } catch (error) {
+      const err = error as Error;
+      if (err.name === 'AbortError') {
+        lastError = new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
+      } else {
+        lastError = err;
+      }
+      logger.warn(`Attempt ${attempt} for ${url} failed: ${lastError.message}`);
+      await delay(backoff);
+      backoff *= 2;
+    }
+  }
+  throw lastError ?? new Error(`Failed to fetch ${url}`);
+}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,23 @@
+export type LogLevel = 'info' | 'warn' | 'error';
+
+function format(level: LogLevel, message: string): string {
+  const ts = new Date().toISOString();
+  return `[${ts}] [${level.toUpperCase()}] ${message}`;
+}
+
+export function log(level: LogLevel, message: string): void {
+  const line = format(level, message);
+  if (level === 'error') {
+    console.error(line);
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+export const logger = {
+  info: (message: string) => log('info', message),
+  warn: (message: string) => log('warn', message),
+  error: (message: string) => log('error', message),
+};

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,25 @@
+import { JsonRpcProvider, Network } from 'ethers';
+import { ARBITRUM_RPC, ARBITRUM_RPC_FALLBACKS } from '../config.js';
+import { logger } from './log.js';
+
+export function createProvider(url: string): JsonRpcProvider {
+  const network = Network.from(42161);
+  return new JsonRpcProvider(url, network, { staticNetwork: network });
+}
+
+export function getProviderUrls(): string[] {
+  const urls = [ARBITRUM_RPC, ...ARBITRUM_RPC_FALLBACKS];
+  const unique = Array.from(new Set(urls.filter((u) => u && u.length > 0)));
+  return unique;
+}
+
+export function buildProviderSequence(): JsonRpcProvider[] {
+  const urls = getProviderUrls();
+  if (urls.length === 0) {
+    throw new Error('No RPC URLs configured');
+  }
+  return urls.map((url) => {
+    logger.info(`Using RPC endpoint ${url}`);
+    return createProvider(url);
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript collectors for on-chain NAV, CoinGecko BTC data, and NAV/BTC analytics with robust utilities
- publish ECharts-based dashboard consuming repo CSVs with time-range filters and summary metrics
- configure hourly and daily GitHub Actions to update datasets, commit results, and deploy GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce87367b548326bef9050934cba128