### PR TITLE
Improve daily deployment workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -5,6 +5,10 @@ on:
     - cron: '20 23 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   daily:
     runs-on: ubuntu-latest
@@ -14,16 +18,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
-      - run: node dist/export_token_price_daily.js
-      - run: node dist/fetch_btc_daily.js
-      - run: node dist/fetch_wbtc_daily.js
-      - run: node dist/build_nav_btc_daily.js
+      - run: npm run daily
       - name: Commit and push CSV updates
         run: |
           if git status --porcelain data | grep .; then
@@ -41,6 +43,8 @@ jobs:
           cp -r public/* pages/
           mkdir -p pages/data
           cp data/*.csv pages/data/
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ One workflow lives under `.github/workflows/`:
 
 - `daily.yml` — runs daily at 23:20 UTC and via manual dispatch. Executes daily NAV + BTC + WBTC fetchers, builds daily metrics, commits CSVs, and deploys GitHub Pages with the dashboard.
 
-The workflow configures `user.name`/`user.email`, only commits when data changes, and pushes to `main`.
+The workflow configures `user.name`/`user.email`, only commits when data changes, and pushes to `main`. To host the dashboard:
+
+1. Open **Settings → Pages** in this repository.
+2. Set the source to **GitHub Actions**.
+3. (Optional) Add repository secrets for premium RPC or HTTP proxies (e.g. `ARBITRUM_RPC`, `HTTPS_PROXY`).
+
+After the first successful workflow run, the site is published at `https://<owner>.github.io/<repo>/` with CSV downloads under `/data/`.
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary
- ensure the daily automation uses full history checkout, runs the bundled `npm run daily` task, and configures GitHub Pages before upload
- add concurrency protection for the deployment job
- document the GitHub Pages setup steps in the README so the static dashboard can be published from Actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecbdc2cac8326a2c9eaf501d4eed5