### PR TITLE
Revamp dashboard UI with dual-language charts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,173 +1,288 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>dHEDGE Vault NAV vs BTC Dashboard</title>
+    <title>Valhalla BTC vs WBTC Dashboard</title>
     <meta name="data-nav-daily" content="data/nav_btc_daily.csv" />
-    <meta name="github-owner" content="" />
-    <meta name="github-repo" content="" />
+    <meta name="data-wbtc-daily" content="data/wbtc_usd_daily.csv" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
     <style>
       :root {
-        color-scheme: light dark;
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background-color: #0f172a;
-        color: #e2e8f0;
+        background-color: #050507;
+        color: #f5f5f5;
       }
+
       body {
         margin: 0;
-        padding: 24px;
         min-height: 100vh;
-        background: linear-gradient(180deg, rgba(15, 23, 42, 1) 0%, rgba(15, 23, 42, 0.85) 100%);
+        background: linear-gradient(135deg, #050507 0%, #101022 100%);
+        color: inherit;
       }
-      header {
+
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 48px 24px 64px;
+      }
+
+      header.top-bar {
         display: flex;
         flex-direction: column;
-        gap: 12px;
-        margin-bottom: 24px;
+        gap: 24px;
       }
+
+      .top-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      .brand {
+        flex: 1 1 320px;
+      }
+
       h1 {
         margin: 0;
-        font-size: 2rem;
-        font-weight: 600;
+        font-size: 2.5rem;
+        font-weight: 700;
+        letter-spacing: 0.01em;
       }
+
       p.description {
-        margin: 0;
+        margin: 12px 0 0;
         max-width: 640px;
-        color: #94a3b8;
+        color: #c9c9d4;
+        font-size: 1rem;
+        line-height: 1.6;
       }
+
+      .toolbar {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+      }
+
+      .language-switcher {
+        display: inline-flex;
+        padding: 4px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .language-switcher button {
+        position: relative;
+        padding: 6px 16px;
+        border: none;
+        background: transparent;
+        color: #f5f5f5;
+        font-size: 0.875rem;
+        font-weight: 600;
+        cursor: pointer;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .language-switcher button.active {
+        background: linear-gradient(135deg, #00e0ff 0%, #7b61ff 100%);
+        color: #050507;
+      }
+
       .filters {
         display: flex;
-        gap: 8px;
+        gap: 12px;
         flex-wrap: wrap;
       }
+
       .filters button {
-        padding: 6px 12px;
-        border: 1px solid #334155;
+        padding: 8px 18px;
         border-radius: 999px;
-        background: rgba(51, 65, 85, 0.4);
+        border: 1px solid rgba(0, 224, 255, 0.4);
+        background: rgba(15, 17, 32, 0.6);
         color: inherit;
+        font-weight: 500;
         cursor: pointer;
-        transition: background 0.2s ease, transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
       }
+
       .filters button:hover {
-        background: rgba(59, 130, 246, 0.25);
-        transform: translateY(-1px);
+        transform: translateY(-2px);
+        background: rgba(0, 224, 255, 0.15);
       }
+
       .filters button.active {
-        background: #38bdf8;
-        color: #0f172a;
+        background: linear-gradient(135deg, #00e0ff 0%, #7b61ff 100%);
         border-color: transparent;
+        color: #050507;
         font-weight: 600;
       }
+
       .cards {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 16px;
-        margin-bottom: 24px;
+        gap: 20px;
+        margin: 32px 0;
       }
+
       .card {
-        padding: 16px;
-        border-radius: 16px;
-        background: rgba(15, 23, 42, 0.8);
-        border: 1px solid rgba(148, 163, 184, 0.1);
+        padding: 20px;
+        border-radius: 24px;
+        background: rgba(17, 17, 26, 0.9);
+        border: 1px solid rgba(0, 224, 255, 0.15);
+        box-shadow: 0 20px 40px rgba(5, 5, 15, 0.35);
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 10px;
       }
+
       .card span.label {
-        font-size: 0.875rem;
-        color: #94a3b8;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-      }
-      .card span.value {
-        font-size: 1.75rem;
+        font-size: 0.85rem;
         font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #7c7c8f;
       }
+
+      .card span.value {
+        font-size: 2rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
+      .card span.delta {
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: #c9c9d4;
+      }
+
+      .card span.delta.positive {
+        color: #00e0ff;
+      }
+
+      .card span.delta.negative {
+        color: #ff6b6b;
+      }
+
       .chart-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 24px;
       }
+
       .chart {
-        height: 320px;
-        background: rgba(15, 23, 42, 0.8);
-        border-radius: 16px;
-        border: 1px solid rgba(148, 163, 184, 0.1);
-        padding: 16px;
+        background: rgba(17, 17, 26, 0.9);
+        border-radius: 24px;
+        padding: 20px;
+        border: 1px solid rgba(0, 224, 255, 0.15);
+        box-shadow: 0 20px 40px rgba(5, 5, 15, 0.35);
       }
+
       .chart h2 {
         margin: 0 0 12px;
-        font-size: 1rem;
+        font-size: 1.1rem;
         font-weight: 600;
+        color: #f5f5f5;
       }
+
       .chart-container {
         width: 100%;
-        height: calc(100% - 24px);
+        height: 320px;
       }
+
       footer {
-        margin-top: 32px;
-        font-size: 0.75rem;
-        color: #64748b;
+        margin-top: 48px;
+        font-size: 0.85rem;
+        color: #7c7c8f;
+        line-height: 1.6;
       }
+
       a {
-        color: #38bdf8;
+        color: #00e0ff;
+      }
+
+      @media (max-width: 768px) {
+        .page {
+          padding: 32px 16px 48px;
+        }
+
+        h1 {
+          font-size: 2rem;
+        }
+
+        .chart-container {
+          height: 260px;
+        }
       }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
     <script src="dashboard.js" defer></script>
   </head>
   <body>
-    <header>
-      <h1>dHEDGE Vault NAV vs BTC</h1>
-      <p class="description">
-        Daily net asset value per share (USD) for the dHEDGE vault at
-        0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9, benchmarked against Bitcoin (BTC/USD).
-        Data refreshes automatically every 10 minutes.
-      </p>
-      <div class="filters" role="group" aria-label="Select time range">
-        <button data-range="1D" class="active">1D</button>
-        <button data-range="1W">1W</button>
-        <button data-range="1M">1M</button>
-        <button data-range="3M">3M</button>
-        <button data-range="YTD">YTD</button>
-        <button data-range="ALL">ALL</button>
-      </div>
-    </header>
-    <section class="cards">
-      <div class="card" aria-live="polite">
-        <span class="label">ROI in BTC</span>
-        <span class="value" id="roi-btc">--</span>
-      </div>
-      <div class="card" aria-live="polite">
-        <span class="label">Alpha vs BTC</span>
-        <span class="value" id="alpha-btc">--</span>
-      </div>
-      <div class="card" aria-live="polite">
-        <span class="label">NAV in BTC</span>
-        <span class="value" id="nav-btc">--</span>
-      </div>
-    </section>
-    <section class="chart-grid">
-      <div class="chart">
-        <h2>ROI in BTC (%)</h2>
-        <div id="chart-roi-btc" class="chart-container"></div>
-      </div>
-      <div class="chart">
-        <h2>Alpha vs BTC (%)</h2>
-        <div id="chart-alpha" class="chart-container"></div>
-      </div>
-      <div class="chart">
-        <h2>NAV per Share (BTC)</h2>
-        <div id="chart-nav" class="chart-container"></div>
-      </div>
-    </section>
-    <footer>
-      Built with public data from CoinGecko and Arbitrum. Charts powered by ECharts. Updates daily via
-      GitHub Actions.
-    </footer>
+    <div class="page">
+      <header class="top-bar">
+        <div class="top-row">
+          <div class="brand">
+            <h1 id="header-title">Valhalla BTC против WBTC</h1>
+            <p class="description" id="header-description">
+              Ежедневные данные фонда Valhalla BTC, сравнение с динамикой WBTC. Информация обновляется автоматически
+              каждые 10 минут.
+            </p>
+          </div>
+          <div class="toolbar">
+            <div class="language-switcher" role="group" aria-label="Выбор языка">
+              <button type="button" class="active" data-language="ru">RU</button>
+              <button type="button" data-language="en">EN</button>
+            </div>
+          </div>
+        </div>
+        <div class="filters" role="group" aria-label="Выбор периода">
+          <button data-range="1D" class="active">1Д</button>
+          <button data-range="1W">1Н</button>
+          <button data-range="1M">1М</button>
+          <button data-range="3M">3М</button>
+          <button data-range="YTD">СГ</button>
+          <button data-range="ALL">ВСЁ</button>
+        </div>
+      </header>
+      <section class="cards">
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-vlhx-label">VLHXBTC</span>
+          <span class="value" id="card-vlhx-price">--</span>
+          <span class="delta" id="card-vlhx-change">--</span>
+        </div>
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-wbtc-label">WBTC</span>
+          <span class="value" id="card-wbtc-price">--</span>
+          <span class="delta" id="card-wbtc-change">--</span>
+        </div>
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-spread-label">Разница в изменении</span>
+          <span class="value" id="card-spread">--</span>
+          <span class="delta" id="card-spread-note">Изменение VLHXBTC минус изменение WBTC</span>
+        </div>
+      </section>
+      <section class="chart-grid">
+        <div class="chart">
+          <h2 id="chart-price-title">Цена WBTC и VLHXBTC (USD)</h2>
+          <div id="chart-price" class="chart-container"></div>
+        </div>
+        <div class="chart">
+          <h2 id="chart-change-title">Изменение цен WBTC и VLHXBTC (%)</h2>
+          <div id="chart-change" class="chart-container"></div>
+        </div>
+        <div class="chart">
+          <h2 id="chart-diff-title">Разница изменения (%)</h2>
+          <div id="chart-diff" class="chart-container"></div>
+        </div>
+      </section>
+      <footer id="footer-text">
+        Данные получены из открытых источников (CoinGecko, Arbitrum) и обновляются ежедневно. Визуализация с помощью
+        ECharts.
+      </footer>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the public dashboard to mirror the vlhx.io look & feel and default to Russian copy with an English toggle
- load WBTC pricing data alongside VLHXBTC and add combined price, percent change, and spread charts that react to range filters
- recalculate the metric cards for the selected period so they track VLHXBTC, WBTC, and their performance difference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced737eb1483269ca6cd7d08b2e4c7