### PR TITLE
Revamp dashboard UI with dual-language charts

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,17 +1,123 @@
 const RANGE_CONFIG = {
   '1D': { days: 1 },
-  '1W': { days: 7 },
   '1M': { days: 30 },
   '3M': { days: 90 },
-  YTD: { ytd: true },
+  '6M': { days: 180 },
   ALL: { all: true },
 };
+
+const RANGE_ORDER = ['1D', '1M', '3M', '6M', 'ALL'];
+
+const TRANSLATIONS = {
+  ru: {
+    title: 'Valhalla BTC против WBTC',
+    description:
+      'Ежедневные данные фонда Valhalla BTC, сравнение с динамикой WBTC. Информация обновляется автоматически каждые 10 минут.',
+    footer: 'Данные получены из открытых источников (CoinGecko, Arbitrum) и обновляются ежедневно. Визуализация с помощью ECharts.',
+    filters: {
+      '1D': '1Д',
+      '1M': '1М',
+      '3M': '3М',
+      '6M': '6М',
+      ALL: 'Всё',
+    },
+    cards: {
+      vlhx: { label: 'VLHXBTC', change: 'Изменение за период' },
+      wbtc: { label: 'WBTC', change: 'Изменение за период' },
+      spread: { label: 'Разница в изменении', note: 'Изменение VLHXBTC минус изменение WBTC' },
+    },
+    charts: {
+      price: {
+        title: 'Цена WBTC и VLHXBTC (USD)',
+        series: {
+          wbtc: 'Цена WBTC',
+          vlhx: 'Цена VLHXBTC',
+        },
+      },
+      change: {
+        title: 'Изменение цен WBTC и VLHXBTC (%)',
+        series: {
+          wbtc: 'Изменение WBTC',
+          vlhx: 'Изменение VLHXBTC',
+        },
+      },
+      diff: {
+        title: 'Разница изменения (%)',
+        series: {
+          diff: 'Разница изменений',
+        },
+      },
+    },
+  },
+  en: {
+    title: 'Valhalla BTC vs WBTC',
+    description:
+      'Daily metrics for the Valhalla BTC fund benchmarked against WBTC. Data refreshes automatically every 10 minutes.',
+    footer: 'Data is sourced from public feeds (CoinGecko, Arbitrum) and updates daily. Visualised with ECharts.',
+    filters: {
+      '1D': '1D',
+      '1M': '1M',
+      '3M': '3M',
+      '6M': '6M',
+      ALL: 'All',
+    },
+    cards: {
+      vlhx: { label: 'VLHXBTC', change: 'Change over period' },
+      wbtc: { label: 'WBTC', change: 'Change over period' },
+      spread: { label: 'Performance spread', note: 'VLHXBTC change minus WBTC change' },
+    },
+    charts: {
+      price: {
+        title: 'WBTC and VLHXBTC Price (USD)',
+        series: {
+          wbtc: 'WBTC Price',
+          vlhx: 'VLHXBTC Price',
+        },
+      },
+      change: {
+        title: 'WBTC and VLHXBTC Price Change (%)',
+        series: {
+          wbtc: 'WBTC Change',
+          vlhx: 'VLHXBTC Change',
+        },
+      },
+      diff: {
+        title: 'Change Difference (%)',
+        series: {
+          diff: 'Change spread',
+        },
+      },
+    },
+  },
+};
+
+const COLORS = {
+  accent: '#00a0d0',
+  secondary: '#ffffff',
+  warning: '#f7931a',
+  background: '#000000',
+  grid: '#1f1f1f',
+  subtleText: '#b3b3b3',
+  strongText: '#ffffff',
+};
+
+const LEGEND_LINE_ICON = 'path://M4 10 L28 10';
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const state = {
   daily: [],
   range: '1D',
   charts: {},
+  language: 'ru',
 };
+
+function getTranslations() {
+  return TRANSLATIONS[state.language] || TRANSLATIONS.ru;
+}
+
+function getLocale() {
+  return state.language === 'ru' ? 'ru-RU' : 'en-US';
+}
 
 function getMetaContent(name) {
   const el = document.querySelector(`meta[name="${name}"]`);
@@ -83,166 +189,549 @@ function parseCsv(text) {
   return rows;
 }
 
-function toDailyData(rows) {
-  return rows.map((row) => ({
-    date: new Date(`${row.day}T00:00:00Z`),
-    nav_btc: Number(row.nav_btc),
-    roi_in_btc: Number(row.roi_in_btc) * 100,
-    roi_in_usd: Number(row.roi_in_usd) * 100,
-    alpha_vs_btc: Number(row.alpha_vs_btc) * 100,
-  }));
+function parseNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return Number.NaN;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : Number.NaN;
+}
+
+function toDailyData(rows, wbtcMap = new Map()) {
+  return rows
+    .map((row) => {
+      const date = new Date(`${row.day}T00:00:00Z`);
+      return {
+        date,
+        isoDate: row.day,
+        nav_usd: parseNumber(row.nav_usd),
+        nav_btc: parseNumber(row.nav_btc),
+        roi_in_btc: parseNumber(row.roi_in_btc) * 100,
+        roi_in_usd: parseNumber(row.roi_in_usd) * 100,
+        alpha_vs_btc: parseNumber(row.alpha_vs_btc) * 100,
+        btc_usd: parseNumber(row.btc_usd),
+        wbtc_usd: parseNumber(wbtcMap.get(row.day)),
+      };
+    })
+    .filter((row) => row.date instanceof Date && !Number.isNaN(row.date.getTime()))
+    .sort((a, b) => a.date - b.date);
 }
 
 function filterData(rangeKey) {
-  const config = RANGE_CONFIG[rangeKey] || RANGE_CONFIG['ALL'];
-  const now = new Date();
+  const config = RANGE_CONFIG[rangeKey] || RANGE_CONFIG.ALL;
   const dataset = state.daily;
-  if (config.all || dataset.length === 0) {
+  if (dataset.length === 0) {
     return dataset;
   }
-  if (config.ytd) {
-    const start = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
-    return dataset.filter((row) => row.date >= start);
+  if (config.all) {
+    return dataset;
   }
+  const lastDate = dataset[dataset.length - 1].date;
   if (config.days) {
-    const start = new Date(now.getTime() - config.days * 24 * 60 * 60 * 1000);
+    const offsetDays = Math.max(config.days - 1, 0);
+    const start = new Date(lastDate.getTime() - offsetDays * DAY_MS);
     return dataset.filter((row) => row.date >= start);
   }
   return dataset;
 }
 
-function formatPercent(value) {
+function formatCurrency(value) {
   if (!Number.isFinite(value)) {
     return '--';
   }
-  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+  return new Intl.NumberFormat(getLocale(), {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value < 2 ? 4 : 2,
+  }).format(value);
 }
 
-function formatBtc(value) {
+function formatPercent(value, digits = 2) {
   if (!Number.isFinite(value)) {
     return '--';
   }
-  return `${value.toFixed(8)} BTC`;
+  const formatted = value.toFixed(digits);
+  return `${value > 0 ? '+' : ''}${formatted}%`;
 }
 
-function updateCards() {
-  const source = state.daily;
-  if (source.length === 0) {
+function computeChange(start, end) {
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start === 0) {
+    return Number.NaN;
+  }
+  return ((end - start) / Math.abs(start)) * 100;
+}
+
+function computePercentChangeData(filtered, key) {
+  const valid = filtered.filter((row) => Number.isFinite(row[key]));
+  if (valid.length === 0) {
+    return [];
+  }
+  const base = valid[0][key];
+  return valid.map((row) => ({
+    timestamp: row.date.getTime(),
+    isoDate: row.isoDate,
+    change: computeChange(base, row[key]),
+  }));
+}
+
+function computeDifferenceSeries(navChanges, wbtcChanges) {
+  const wbtcMap = new Map(wbtcChanges.map((item) => [item.isoDate, item.change]));
+  return navChanges
+    .map((item) => {
+      const wbtcChange = wbtcMap.get(item.isoDate);
+      if (!Number.isFinite(wbtcChange)) {
+        return null;
+      }
+      return [item.timestamp, item.change - wbtcChange];
+    })
+    .filter(Boolean);
+}
+
+function setDeltaClass(element, value) {
+  element.classList.remove('positive', 'negative');
+  if (!Number.isFinite(value)) {
     return;
   }
-  const latest = source[source.length - 1];
-  document.getElementById('roi-btc').textContent = formatPercent(latest.roi_in_btc);
-  document.getElementById('alpha-btc').textContent = formatPercent(latest.alpha_vs_btc);
-  document.getElementById('nav-btc').textContent = formatBtc(latest.nav_btc);
+  element.classList.add(value >= 0 ? 'positive' : 'negative');
 }
 
-function initCharts() {
-  state.charts.roi = echarts.init(document.getElementById('chart-roi-btc'));
-  state.charts.alpha = echarts.init(document.getElementById('chart-alpha'));
-  state.charts.nav = echarts.init(document.getElementById('chart-nav'));
-  window.addEventListener('resize', () => {
-    Object.values(state.charts).forEach((chart) => chart.resize());
-  });
+function updateCards(filtered) {
+  const t = getTranslations();
+  const navRows = filtered.filter((row) => Number.isFinite(row.nav_usd));
+  const wbtcRows = filtered.filter((row) => Number.isFinite(row.wbtc_usd));
+
+  const navFirst = navRows[0];
+  const navLast = navRows[navRows.length - 1];
+  const wbtcFirst = wbtcRows[0];
+  const wbtcLast = wbtcRows[wbtcRows.length - 1];
+
+  const navChange = computeChange(navFirst?.nav_usd, navLast?.nav_usd);
+  const wbtcChange = computeChange(wbtcFirst?.wbtc_usd, wbtcLast?.wbtc_usd);
+  const spreadChange = Number.isFinite(navChange) && Number.isFinite(wbtcChange) ? navChange - wbtcChange : Number.NaN;
+
+  const vlhxPriceEl = document.getElementById('card-vlhx-price');
+  const vlhxChangeEl = document.getElementById('card-vlhx-change');
+  const wbtcPriceEl = document.getElementById('card-wbtc-price');
+  const wbtcChangeEl = document.getElementById('card-wbtc-change');
+  const spreadEl = document.getElementById('card-spread');
+  const spreadNoteEl = document.getElementById('card-spread-note');
+
+  vlhxPriceEl.textContent = formatCurrency(navLast?.nav_usd);
+  vlhxChangeEl.textContent = `${t.cards.vlhx.change}: ${formatPercent(navChange)}`;
+  setDeltaClass(vlhxChangeEl, navChange);
+
+  wbtcPriceEl.textContent = formatCurrency(wbtcLast?.wbtc_usd);
+  wbtcChangeEl.textContent = `${t.cards.wbtc.change}: ${formatPercent(wbtcChange)}`;
+  setDeltaClass(wbtcChangeEl, wbtcChange);
+
+  spreadEl.textContent = formatPercent(spreadChange);
+  setDeltaClass(spreadEl, spreadChange);
+  spreadNoteEl.textContent = t.cards.spread.note;
 }
 
-function chartOptions(title, dataKey, data) {
-  const seriesData = data.map((row) => [row.date.getTime(), row[dataKey]]);
-  const isPercent = dataKey !== 'nav_btc';
+function createCommonChartOptions() {
   return {
-    tooltip: {
-      trigger: 'axis',
-      valueFormatter: (value) =>
-        isPercent ? `${value >= 0 ? '+' : ''}${Number(value).toFixed(2)}%` : `${Number(value).toFixed(8)} BTC`,
+    backgroundColor: COLORS.background,
+    grid: {
+      left: 52,
+      right: 52,
+      top: 48,
+      bottom: 64,
+    },
+    textStyle: {
+      color: COLORS.strongText,
+      fontFamily: 'Inter, sans-serif',
     },
     xAxis: {
       type: 'time',
-      axisLabel: {
-        color: '#94a3b8',
-      },
+      axisLine: { lineStyle: { color: COLORS.grid } },
+      axisLabel: { color: COLORS.subtleText, hideOverlap: true, padding: [8, 0, 0, 0] },
+      splitLine: { show: false },
     },
     yAxis: {
       type: 'value',
-      axisLabel: {
-        color: '#94a3b8',
-        formatter: (value) => (isPercent ? `${value.toFixed(0)}%` : value.toFixed(4)),
-      },
-      splitLine: {
-        lineStyle: {
-          color: 'rgba(148, 163, 184, 0.2)',
-        },
-      },
+      axisLine: { show: false },
+      axisLabel: { color: COLORS.subtleText },
+      splitLine: { lineStyle: { color: COLORS.grid } },
     },
-    grid: {
-      left: 40,
-      right: 16,
-      top: 20,
-      bottom: 40,
-    },
-    series: [
-      {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
         type: 'line',
-        smooth: true,
-        showSymbol: false,
-        data: seriesData,
-        lineStyle: {
-          width: 2,
-        },
-        areaStyle: {
-          opacity: 0.08,
-        },
+        lineStyle: { color: COLORS.accent, width: 1 },
       },
-    ],
-    textStyle: {
-      color: '#e2e8f0',
     },
-    backgroundColor: 'transparent',
+    legend: {
+      top: 0,
+      textStyle: { color: COLORS.subtleText, fontSize: 12 },
+      icon: LEGEND_LINE_ICON,
+      itemWidth: 24,
+      itemHeight: 6,
+    },
+    color: [COLORS.accent, COLORS.secondary, COLORS.warning],
   };
 }
 
-function updateCharts(rangeKey) {
-  const filtered = filterData(rangeKey);
-  Object.entries({
-    roi: 'roi_in_btc',
-    alpha: 'alpha_vs_btc',
-    nav: 'nav_btc',
-  }).forEach(([chartKey, dataKey]) => {
-    const chart = state.charts[chartKey];
-    if (!chart) return;
-    if (filtered.length === 0) {
-      chart.clear();
-      return;
+function formatAxisDate(value) {
+  const locale = getLocale();
+  const date = new Date(value);
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const formatted = new Intl.DateTimeFormat(locale, {
+    day: '2-digit',
+    month: 'short',
+  }).format(date);
+  const normalized = formatted.replace(/\u00a0/g, ' ');
+  return normalized.replace('.', '').replace(' ', '\n');
+}
+
+function hexToRgba(hex, alpha) {
+  const sanitized = hex.replace('#', '');
+  if (sanitized.length !== 6) {
+    return hex;
+  }
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function buildLineSeries({ name, data, color, yAxisIndex = 0 }) {
+  return {
+    name,
+    type: 'line',
+    smooth: true,
+    showSymbol: false,
+    data,
+    yAxisIndex,
+    color,
+    lineStyle: { width: 2, color },
+    areaStyle: {
+      color: {
+        type: 'linear',
+        x: 0,
+        y: 0,
+        x2: 0,
+        y2: 1,
+        colorStops: [
+          { offset: 0, color: hexToRgba(color, 0.18) },
+          { offset: 1, color: hexToRgba(color, 0) },
+        ],
+      },
+    },
+  };
+}
+
+function updatePriceChart(filtered) {
+  const chart = state.charts.price;
+  if (!chart) return;
+  const t = getTranslations();
+  const locale = getLocale();
+  const wbtcSeries = [];
+  const vlhxSeries = [];
+
+  filtered.forEach((row) => {
+    const timestamp = row.date.getTime();
+    if (Number.isFinite(row.wbtc_usd)) {
+      wbtcSeries.push([timestamp, row.wbtc_usd]);
     }
-    chart.setOption(chartOptions(chartKey, dataKey, filtered));
+    if (Number.isFinite(row.nav_usd)) {
+      vlhxSeries.push([timestamp, row.nav_usd]);
+    }
   });
+
+  if (wbtcSeries.length === 0 && vlhxSeries.length === 0) {
+    chart.clear();
+    return;
+  }
+
+  const option = createCommonChartOptions();
+  option.legend.data = [];
+  option.xAxis.axisLabel.formatter = formatAxisDate;
+  option.yAxis = [
+    {
+      type: 'value',
+      axisLine: { show: false },
+      axisLabel: {
+        color: COLORS.subtleText,
+        formatter: (value) =>
+          new Intl.NumberFormat(locale, { maximumFractionDigits: value < 200 ? 2 : 0 }).format(value),
+      },
+      splitLine: { lineStyle: { color: COLORS.grid } },
+    },
+    {
+      type: 'value',
+      axisLine: { show: false },
+      axisLabel: {
+        color: COLORS.subtleText,
+        formatter: (value) =>
+          new Intl.NumberFormat(locale, { maximumFractionDigits: value < 2 ? 4 : 2 }).format(value),
+      },
+      splitLine: { show: false },
+      position: 'right',
+    },
+  ];
+  option.tooltip.valueFormatter = (value) => formatCurrency(Number(value));
+  option.series = [];
+
+  if (wbtcSeries.length > 0) {
+    option.legend.data.push(t.charts.price.series.wbtc);
+    option.series.push(
+      buildLineSeries({
+        name: t.charts.price.series.wbtc,
+        data: wbtcSeries,
+        color: COLORS.secondary,
+        yAxisIndex: 0,
+      }),
+    );
+  }
+
+  if (vlhxSeries.length > 0) {
+    option.legend.data.push(t.charts.price.series.vlhx);
+    option.series.push(
+      buildLineSeries({
+        name: t.charts.price.series.vlhx,
+        data: vlhxSeries,
+        color: COLORS.accent,
+        yAxisIndex: 1,
+      }),
+    );
+  }
+  chart.setOption(option, true);
+}
+
+function updateChangeChart(filtered) {
+  const chart = state.charts.change;
+  if (!chart) return;
+  const t = getTranslations();
+
+  const navChanges = computePercentChangeData(filtered, 'nav_usd');
+  const wbtcChanges = computePercentChangeData(filtered, 'wbtc_usd');
+
+  if (navChanges.length === 0 && wbtcChanges.length === 0) {
+    chart.clear();
+    return;
+  }
+
+  const option = createCommonChartOptions();
+  option.legend.data = [];
+  option.xAxis.axisLabel.formatter = formatAxisDate;
+  option.yAxis.axisLabel.formatter = (value) => `${value.toFixed(1)}%`;
+  option.tooltip.valueFormatter = (value) => formatPercent(Number(value));
+  option.series = [];
+
+  if (wbtcChanges.length > 0) {
+    option.legend.data.push(t.charts.change.series.wbtc);
+    option.series.push(
+      buildLineSeries({
+        name: t.charts.change.series.wbtc,
+        data: wbtcChanges.map((item) => [item.timestamp, item.change]),
+        color: COLORS.secondary,
+      }),
+    );
+  }
+
+  if (navChanges.length > 0) {
+    option.legend.data.push(t.charts.change.series.vlhx);
+    option.series.push(
+      buildLineSeries({
+        name: t.charts.change.series.vlhx,
+        data: navChanges.map((item) => [item.timestamp, item.change]),
+        color: COLORS.accent,
+      }),
+    );
+  }
+  chart.setOption(option, true);
+}
+
+function updateDiffChart(filtered) {
+  const chart = state.charts.diff;
+  if (!chart) return;
+  const t = getTranslations();
+
+  const navChanges = computePercentChangeData(filtered, 'nav_usd');
+  const wbtcChanges = computePercentChangeData(filtered, 'wbtc_usd');
+  const diffSeries = computeDifferenceSeries(navChanges, wbtcChanges);
+
+  if (diffSeries.length === 0) {
+    chart.clear();
+    return;
+  }
+
+  const option = createCommonChartOptions();
+  option.legend.data = [t.charts.diff.series.diff];
+  option.xAxis.axisLabel.formatter = formatAxisDate;
+  option.yAxis.axisLabel.formatter = (value) => `${value.toFixed(1)}%`;
+  option.tooltip.valueFormatter = (value) => formatPercent(Number(value));
+  option.color = [COLORS.warning];
+  option.series = [
+    buildLineSeries({
+      name: t.charts.diff.series.diff,
+      data: diffSeries,
+      color: COLORS.warning,
+    }),
+  ];
+  chart.setOption(option, true);
+}
+
+function updateCharts(filtered) {
+  updatePriceChart(filtered);
+  updateChangeChart(filtered);
+  updateDiffChart(filtered);
+}
+
+function refreshUI() {
+  const filtered = filterData(state.range);
+  updateCards(filtered);
+  updateCharts(filtered);
 }
 
 async function loadData() {
   const dailyPath = getMetaContent('data-nav-daily');
+  const wbtcPath = getMetaContent('data-wbtc-daily');
   try {
-    const dailyText = await fetchCsv(dailyPath);
-    state.daily = toDailyData(parseCsv(dailyText));
-    updateCards();
-    updateCharts(state.range);
+    const [dailyText, wbtcText] = await Promise.all([fetchCsv(dailyPath), fetchCsv(wbtcPath)]);
+    const wbtcRows = parseCsv(wbtcText);
+    const wbtcMap = new Map(wbtcRows.map((row) => [row.day, parseNumber(row.wbtc_usd)]));
+    state.daily = toDailyData(parseCsv(dailyText), wbtcMap);
+    ensureRangeAvailability();
+    updateFilterVisibility();
+    updateFilterLabels();
+    refreshUI();
   } catch (error) {
     console.error('Failed to load dashboard data', error);
   }
+}
+
+function hasDataForRange(rangeKey) {
+  const config = RANGE_CONFIG[rangeKey];
+  const dataset = state.daily;
+  if (!config || dataset.length === 0) {
+    return false;
+  }
+  if (config.all) {
+    return true;
+  }
+  if (config.days) {
+    const lastDate = dataset[dataset.length - 1].date;
+    const start = new Date(lastDate.getTime() - Math.max(config.days - 1, 0) * DAY_MS);
+    return dataset.some((row) => row.date <= start);
+  }
+  return false;
+}
+
+function ensureRangeAvailability() {
+  const available = RANGE_ORDER.filter((key) => hasDataForRange(key));
+  if (!available.includes(state.range)) {
+    state.range = available[0] || 'ALL';
+  }
+  return available;
+}
+
+function updateFilterVisibility() {
+  if (state.daily.length === 0) {
+    document.querySelectorAll('.filters button').forEach((button) => {
+      button.classList.remove('hidden');
+    });
+    return;
+  }
+  const available = ensureRangeAvailability();
+  const availableSet = new Set(available);
+  document.querySelectorAll('.filters button').forEach((button) => {
+    const range = button.dataset.range;
+    const isAvailable = availableSet.has(range);
+    button.classList.toggle('hidden', !isAvailable);
+  });
+}
+
+function updateFilterLabels() {
+  const t = getTranslations();
+  document.querySelectorAll('.filters button').forEach((button) => {
+    const range = button.dataset.range;
+    button.textContent = t.filters[range] || range;
+    button.classList.toggle('active', range === state.range);
+  });
+}
+
+function applyTranslations() {
+  const t = getTranslations();
+  document.getElementById('header-title').textContent = t.title;
+  document.getElementById('header-description').textContent = t.description;
+  document.getElementById('footer-text').textContent = t.footer;
+  document.getElementById('chart-price-title').textContent = t.charts.price.title;
+  document.getElementById('chart-change-title').textContent = t.charts.change.title;
+  document.getElementById('chart-diff-title').textContent = t.charts.diff.title;
+
+  document.querySelector('[data-i18n="card-vlhx-label"]').textContent = t.cards.vlhx.label;
+  document.querySelector('[data-i18n="card-wbtc-label"]').textContent = t.cards.wbtc.label;
+  document.querySelector('[data-i18n="card-spread-label"]').textContent = t.cards.spread.label;
+
+  updateFilterLabels();
+  updateFilterVisibility();
+  document.documentElement.setAttribute('lang', state.language);
+}
+
+function updateLanguageButtons() {
+  document.querySelectorAll('.language-switcher button').forEach((button) => {
+    const lang = button.dataset.language;
+    button.classList.toggle('active', lang === state.language);
+    button.textContent = lang.toUpperCase();
+  });
+}
+
+function setLanguage(lang) {
+  if (!TRANSLATIONS[lang] || lang === state.language) {
+    return;
+  }
+  state.language = lang;
+  applyTranslations();
+  updateLanguageButtons();
+  refreshUI();
+}
+
+function initCharts() {
+  state.charts.price = echarts.init(document.getElementById('chart-price'));
+  state.charts.change = echarts.init(document.getElementById('chart-change'));
+  state.charts.diff = echarts.init(document.getElementById('chart-diff'));
+  window.addEventListener('resize', () => {
+    Object.values(state.charts).forEach((chart) => chart && chart.resize());
+  });
 }
 
 function initFilters() {
   document.querySelectorAll('.filters button').forEach((button) => {
     button.addEventListener('click', () => {
       const range = button.dataset.range;
+      if (range === state.range) {
+        return;
+      }
       state.range = range;
-      document.querySelectorAll('.filters button').forEach((btn) => btn.classList.remove('active'));
-      button.classList.add('active');
-      updateCharts(range);
+      updateFilterLabels();
+      refreshUI();
     });
   });
+  updateFilterLabels();
+  updateFilterVisibility();
+}
+
+function initLanguageSwitcher() {
+  document.querySelectorAll('.language-switcher button').forEach((button) => {
+    button.addEventListener('click', () => {
+      const lang = button.dataset.language;
+      setLanguage(lang);
+    });
+  });
+  updateLanguageButtons();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  applyTranslations();
+  initLanguageSwitcher();
   initCharts();
   initFilters();
+  refreshUI();
   loadData();
   setInterval(loadData, 10 * 60 * 1000);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -1,173 +1,316 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>dHEDGE Vault NAV vs BTC Dashboard</title>
+    <title>Valhalla BTC vs WBTC Dashboard</title>
     <meta name="data-nav-daily" content="data/nav_btc_daily.csv" />
-    <meta name="github-owner" content="" />
-    <meta name="github-repo" content="" />
+    <meta name="data-wbtc-daily" content="data/wbtc_usd_daily.csv" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
     <style>
       :root {
-        color-scheme: light dark;
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background-color: #0f172a;
-        color: #e2e8f0;
+        background-color: #000000;
+        color: #ffffff;
       }
+
       body {
         margin: 0;
-        padding: 24px;
         min-height: 100vh;
-        background: linear-gradient(180deg, rgba(15, 23, 42, 1) 0%, rgba(15, 23, 42, 0.85) 100%);
+        background: #000000;
+        color: inherit;
       }
-      header {
+
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 48px 24px 64px;
+      }
+
+      header.top-bar {
         display: flex;
         flex-direction: column;
-        gap: 12px;
-        margin-bottom: 24px;
+        gap: 24px;
       }
+
+      .top-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      .brand {
+        flex: 1 1 320px;
+      }
+
       h1 {
         margin: 0;
-        font-size: 2rem;
-        font-weight: 600;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        font-size: 2.25rem;
       }
+
       p.description {
-        margin: 0;
+        margin: 24px 0;
         max-width: 640px;
-        color: #94a3b8;
+        color: #b3b3b3;
+        font-size: 1rem;
+        line-height: 1.6;
       }
+
+      .toolbar {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+      }
+
+      .language-switcher {
+        display: inline-flex;
+        border: 1px solid #1f1f1f;
+        background: transparent;
+        border-radius: 0;
+      }
+
+      .language-switcher button {
+        position: relative;
+        padding: 8px 20px;
+        border: none;
+        background: #ffffff;
+        color: #000000;
+        font-size: 0.875rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+        letter-spacing: 0.04em;
+        border-radius: 0;
+      }
+
+      .language-switcher button + button {
+        border-left: 1px solid #1f1f1f;
+      }
+
+      .language-switcher button.active {
+        background: #00a0d0;
+        color: #000000;
+      }
+
       .filters {
         display: flex;
-        gap: 8px;
+        gap: 12px;
         flex-wrap: wrap;
       }
+
       .filters button {
-        padding: 6px 12px;
-        border: 1px solid #334155;
-        border-radius: 999px;
-        background: rgba(51, 65, 85, 0.4);
-        color: inherit;
-        cursor: pointer;
-        transition: background 0.2s ease, transform 0.2s ease;
-      }
-      .filters button:hover {
-        background: rgba(59, 130, 246, 0.25);
-        transform: translateY(-1px);
-      }
-      .filters button.active {
-        background: #38bdf8;
-        color: #0f172a;
-        border-color: transparent;
+        padding: 10px 22px;
+        border: 1px solid #1f1f1f;
+        background: #ffffff;
+        color: #000000;
         font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+        letter-spacing: 0.04em;
+        border-radius: 0;
       }
+
+      .filters button:hover {
+        background: #e5f7fc;
+      }
+
+      .filters button.active {
+        background: #00a0d0;
+        color: #000000;
+        border-color: #00a0d0;
+      }
+
+      .filters button.hidden {
+        display: none;
+      }
+
       .cards {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 16px;
-        margin-bottom: 24px;
+        gap: 20px;
+        margin: 32px 0;
       }
+
       .card {
-        padding: 16px;
-        border-radius: 16px;
-        background: rgba(15, 23, 42, 0.8);
-        border: 1px solid rgba(148, 163, 184, 0.1);
+        padding: 20px;
+        background: #000000;
+        border: 1px solid #1f1f1f;
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 10px;
+        border-radius: 0;
       }
+
       .card span.label {
-        font-size: 0.875rem;
-        color: #94a3b8;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-      }
-      .card span.value {
-        font-size: 1.75rem;
+        font-size: 0.85rem;
         font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #7c7c7c;
       }
+
+      .card span.value {
+        font-size: 2rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
+      .card span.delta {
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: #b3b3b3;
+      }
+
+      .card span.delta.positive {
+        color: #00a0d0;
+      }
+
+      .card span.delta.negative {
+        color: #f7931a;
+      }
+
       .chart-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 24px;
       }
+
       .chart {
-        height: 320px;
-        background: rgba(15, 23, 42, 0.8);
-        border-radius: 16px;
-        border: 1px solid rgba(148, 163, 184, 0.1);
-        padding: 16px;
+        background: #000000;
+        padding: 20px;
+        border: 1px solid #1f1f1f;
+        border-radius: 0;
       }
+
       .chart h2 {
         margin: 0 0 12px;
-        font-size: 1rem;
+        font-size: 1.1rem;
         font-weight: 600;
+        color: #f5f5f5;
       }
+
       .chart-container {
         width: 100%;
-        height: calc(100% - 24px);
+        height: 320px;
       }
+
       footer {
-        margin-top: 32px;
-        font-size: 0.75rem;
-        color: #64748b;
+        margin-top: 48px;
+        font-size: 0.85rem;
+        color: #7c7c7c;
+        line-height: 1.6;
       }
+
       a {
-        color: #38bdf8;
+        color: #00a0d0;
+      }
+
+      @media (max-width: 768px) {
+        .page {
+          padding: 32px 16px 48px;
+        }
+
+        h1 {
+          font-size: 2.25rem;
+        }
+
+        p.description {
+          font-size: 1rem;
+        }
+
+        .chart-container {
+          height: 260px;
+        }
+      }
+
+      @media (max-width: 1199px) {
+        h1 {
+          font-size: 2.25rem;
+        }
+
+        p.description {
+          font-size: 1rem;
+        }
+      }
+
+      @media (min-width: 1200px) {
+        h1 {
+          font-size: 4.25rem;
+        }
+
+        p.description {
+          font-size: 1.25rem;
+        }
       }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
     <script src="dashboard.js" defer></script>
   </head>
   <body>
-    <header>
-      <h1>dHEDGE Vault NAV vs BTC</h1>
-      <p class="description">
-        Daily net asset value per share (USD) for the dHEDGE vault at
-        0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9, benchmarked against Bitcoin (BTC/USD).
-        Data refreshes automatically every 10 minutes.
-      </p>
-      <div class="filters" role="group" aria-label="Select time range">
-        <button data-range="1D" class="active">1D</button>
-        <button data-range="1W">1W</button>
-        <button data-range="1M">1M</button>
-        <button data-range="3M">3M</button>
-        <button data-range="YTD">YTD</button>
-        <button data-range="ALL">ALL</button>
-      </div>
-    </header>
-    <section class="cards">
-      <div class="card" aria-live="polite">
-        <span class="label">ROI in BTC</span>
-        <span class="value" id="roi-btc">--</span>
-      </div>
-      <div class="card" aria-live="polite">
-        <span class="label">Alpha vs BTC</span>
-        <span class="value" id="alpha-btc">--</span>
-      </div>
-      <div class="card" aria-live="polite">
-        <span class="label">NAV in BTC</span>
-        <span class="value" id="nav-btc">--</span>
-      </div>
-    </section>
-    <section class="chart-grid">
-      <div class="chart">
-        <h2>ROI in BTC (%)</h2>
-        <div id="chart-roi-btc" class="chart-container"></div>
-      </div>
-      <div class="chart">
-        <h2>Alpha vs BTC (%)</h2>
-        <div id="chart-alpha" class="chart-container"></div>
-      </div>
-      <div class="chart">
-        <h2>NAV per Share (BTC)</h2>
-        <div id="chart-nav" class="chart-container"></div>
-      </div>
-    </section>
-    <footer>
-      Built with public data from CoinGecko and Arbitrum. Charts powered by ECharts. Updates daily via
-      GitHub Actions.
-    </footer>
+    <div class="page">
+      <header class="top-bar">
+        <div class="top-row">
+          <div class="brand">
+            <h1 id="header-title">Valhalla BTC против WBTC</h1>
+            <p class="description" id="header-description">
+              Ежедневные данные фонда Valhalla BTC, сравнение с динамикой WBTC. Информация обновляется автоматически
+              каждые 10 минут.
+            </p>
+          </div>
+          <div class="toolbar">
+            <div class="language-switcher" role="group" aria-label="Выбор языка">
+              <button type="button" class="active" data-language="ru">RU</button>
+              <button type="button" data-language="en">EN</button>
+            </div>
+          </div>
+        </div>
+        <div class="filters" role="group" aria-label="Выбор периода">
+          <button data-range="1D" class="active">1Д</button>
+          <button data-range="1M">1М</button>
+          <button data-range="3M">3М</button>
+          <button data-range="6M">6М</button>
+          <button data-range="ALL">Всё</button>
+        </div>
+      </header>
+      <section class="cards">
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-vlhx-label">VLHXBTC</span>
+          <span class="value" id="card-vlhx-price">--</span>
+          <span class="delta" id="card-vlhx-change">--</span>
+        </div>
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-wbtc-label">WBTC</span>
+          <span class="value" id="card-wbtc-price">--</span>
+          <span class="delta" id="card-wbtc-change">--</span>
+        </div>
+        <div class="card" aria-live="polite">
+          <span class="label" data-i18n="card-spread-label">Разница в изменении</span>
+          <span class="value" id="card-spread">--</span>
+          <span class="delta" id="card-spread-note">Изменение VLHXBTC минус изменение WBTC</span>
+        </div>
+      </section>
+      <section class="chart-grid">
+        <div class="chart">
+          <h2 id="chart-price-title">Цена WBTC и VLHXBTC (USD)</h2>
+          <div id="chart-price" class="chart-container"></div>
+        </div>
+        <div class="chart">
+          <h2 id="chart-change-title">Изменение цен WBTC и VLHXBTC (%)</h2>
+          <div id="chart-change" class="chart-container"></div>
+        </div>
+        <div class="chart">
+          <h2 id="chart-diff-title">Разница изменения (%)</h2>
+          <div id="chart-diff" class="chart-container"></div>
+        </div>
+      </section>
+      <footer id="footer-text">
+        Данные получены из открытых источников (CoinGecko, Arbitrum) и обновляются ежедневно. Визуализация с помощью
+        ECharts.
+      </footer>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the public dashboard to mirror the vlhx.io look & feel with Inter typography, a flat black palette, and white/accent controls while defaulting to Russian copy with an English toggle
- load WBTC pricing data alongside VLHXBTC and add combined price, percent change, and spread charts that react to range filters, now using dual-axis pricing, legend lines, smoother gradients, and only exposing 1D/1M/3M/6M/All options when data exists
- recalculate the metric cards for the selected period so they track VLHXBTC, WBTC, and their performance difference with the updated color scheme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced737eb1483269ca6cd7d08b2e4c7