### PR TITLE
Trigger daily workflow on main pushes

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,6 +1,9 @@
 name: Daily Data Update
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     # Run once per day at 23:00 UTC so CoinGecko & on-chain data have settled.
     - cron: '0 23 * * *'


### PR DESCRIPTION
## Summary
- add a push trigger on the main branch so the daily workflow runs automatically after merges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee9cc15288326b4129ba8e0080451