### PR TITLE
Refine invest link layout for desktop view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,33 +52,26 @@
         height: 16px;
       }
 
-      .header-actions {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-      }
-
       .invest-button {
         display: none;
-        align-items: center;
-        justify-content: center;
-        width: 197px;
-        height: 40px;
-        padding: 8px 24px;
-        border-radius: 4px;
-        background: #ffffff;
-        color: #000000;
+        background: transparent;
+        color: #ffffff;
         font-size: 0.875rem;
         font-weight: 600;
         text-decoration: none;
         letter-spacing: 0.02em;
-        transition: background 0.2s ease, color 0.2s ease;
+        transition: color 0.2s ease;
       }
 
       .invest-button:hover,
       .invest-button:focus {
-        background: #f1f1f1;
-        color: #000000;
+        color: #00a0d0;
+      }
+
+      .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 24px;
       }
 
       .language-toggle {
@@ -97,8 +90,7 @@
       }
 
       .language-toggle::after {
-        content: '✓';
-        font-size: 0.75rem;
+        content: '';
       }
 
       .brand {
@@ -276,6 +268,8 @@
       @media (min-width: 1200px) {
         .invest-button {
           display: inline-flex;
+          padding: 10px 24px;
+          margin: 18px 0;
         }
 
         h1 {


### PR DESCRIPTION
## Summary
- render the invest call-to-action as a text-style link with transparent background
- show the invest link only from desktop widths with 10px/24px padding and 18px vertical margin
- increase spacing between the invest link and language toggle for clearer separation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfb4ceef58832693a3af197d653fa2