### PR TITLE
Improve responsive layout to match landing breakpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,8 +84,10 @@ export function App(): JSX.Element {
         availableRanges={availableRanges}
         onRangeChange={handleRangeChange}
       />
-      <CardsSection stats={stats} translation={translation} locale={locale} />
-      <ChartsSection data={filteredData} translation={translation} locale={locale} />
+      <main className="content">
+        <CardsSection stats={stats} translation={translation} locale={locale} />
+        <ChartsSection data={filteredData} translation={translation} locale={locale} />
+      </main>
       <footer>{translation.footer}</footer>
     </div>
   );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,10 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background-color: #000000;
   color: #ffffff;
+  --page-padding-x: 24px;
+  --page-padding-y: 80px;
+  --section-gap: clamp(40px, 6vw, 96px);
+  --content-gap: clamp(40px, 5vw, 80px);
 }
 
 * {
@@ -18,15 +22,24 @@ body {
 }
 
 .page {
-  max-width: 1200px;
+  width: 100%;
+  max-width: 1920px;
   margin: 0 auto;
-  padding: 48px 24px 64px;
+  padding: var(--page-padding-y) var(--page-padding-x);
+  display: flex;
+  flex-direction: column;
+  gap: var(--section-gap);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--content-gap);
 }
 
 .top-bar {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
+  display: grid;
+  gap: clamp(24px, 4vw, 48px);
 }
 
 .header-nav {
@@ -67,6 +80,8 @@ body {
   display: flex;
   align-items: center;
   gap: 24px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .language-toggle {
@@ -88,20 +103,21 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  max-width: min(100%, 760px);
 }
 
 h1 {
   margin: 0;
   font-weight: 700;
   letter-spacing: 0.01em;
-  font-size: 2.25rem;
+  font-size: clamp(2rem, 6vw, 4.25rem);
 }
 
 .description {
   margin: 24px 0;
-  max-width: 640px;
+  max-width: min(100%, 720px);
   color: #b3b3b3;
-  font-size: 1rem;
+  font-size: clamp(1rem, 1.8vw, 1.25rem);
   line-height: 1.6;
 }
 
@@ -109,6 +125,7 @@ h1 {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .filters button {
@@ -139,34 +156,33 @@ h1 {
 }
 
 .cards {
-  margin-top: 48px;
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .card {
   background: #0d0d0d;
   border-radius: 16px;
-  padding: 24px;
+  padding: clamp(20px, 2.5vw, 28px);
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
 .card .label {
-  font-size: 0.875rem;
+  font-size: clamp(0.75rem, 1vw, 0.875rem);
   font-weight: 600;
   color: #b3b3b3;
 }
 
 .card .value {
-  font-size: 1.75rem;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
   font-weight: 700;
 }
 
 .card .delta {
-  font-size: 0.875rem;
+  font-size: clamp(0.75rem, 1vw, 0.875rem);
   font-weight: 600;
   color: #b3b3b3;
 }
@@ -182,60 +198,108 @@ h1 {
 }
 
 .chart-grid {
-  margin-top: 56px;
   display: grid;
   gap: 32px;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .chart {
   background: #0d0d0d;
   border-radius: 16px;
-  padding: 24px 24px 16px;
+  padding: clamp(20px, 2.5vw, 32px) clamp(20px, 2.5vw, 32px) clamp(16px, 2vw, 28px);
 }
 
 .chart h2 {
   margin: 0 0 16px;
-  font-size: 1.25rem;
+  font-size: clamp(1.125rem, 1.4vw, 1.5rem);
 }
 
 .chart-container {
   width: 100%;
-  height: 360px;
+  height: clamp(240px, 32vw, 420px);
 }
 
 footer {
-  margin-top: 64px;
   color: #b3b3b3;
   font-size: 0.875rem;
   line-height: 1.6;
 }
 
-@media (max-width: 767px) {
-  .page {
-    padding: 32px 16px 48px;
-  }
-
-  .chart-container {
-    height: 260px;
-  }
-
+@media (max-width: 480px) {
   .logo-link img {
     height: 12px;
   }
 }
 
+@media (min-width: 640px) {
+  :root {
+    --page-padding-x: 80px;
+    --page-padding-y: 80px;
+  }
+
+  .filters {
+    gap: 16px;
+  }
+
+  .cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --page-padding-x: 80px;
+    --page-padding-y: 160px;
+  }
+
+  .top-bar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: end;
+    row-gap: clamp(32px, 5vw, 64px);
+  }
+
+  .header-nav {
+    grid-column: 1 / -1;
+  }
+
+  .brand {
+    grid-column: 1 / 2;
+  }
+
+  .filters {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+
+  .cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .chart-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 1200px) {
+  :root {
+    --page-padding-x: 126px;
+    --page-padding-y: 160px;
+  }
+
   .invest-button {
     display: inline-flex;
     padding: 10px 24px;
-    margin: 18px 0;
+    border-radius: 9999px;
   }
 
-  h1 {
-    font-size: 4.25rem;
+  .chart-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+}
 
-  .description {
-    font-size: 1.25rem;
+@media (min-width: 1920px) {
+  :root {
+    --page-padding-x: 240px;
+    --page-padding-y: 160px;
   }
 }


### PR DESCRIPTION
## Summary
- wrap dashboard sections in a main container to control vertical rhythm
- rework global styles with responsive container paddings aligned to landing breakpoints
- tune card and chart typography, spacing, and grid behavior for fluid layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfda685a84832685e989ba4d339b8b