### PR TITLE
Fix unmatched brace in global CSS media query

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -246,7 +246,6 @@ footer {
     --page-padding-x: 80px;
     --page-padding-y: 80px;
   }
-}
 
   .logo-link img {
     height: 16px;


### PR DESCRIPTION
## Summary
- remove the extra closing brace that prematurely ended the 640px media query in `global.css`
- ensure the `.logo-link` and `.cards` rules stay inside the media query block so the stylesheet parses correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe87f687c8326bad412d2886e8ca4