### PR TITLE
Improve chart formatting and responsiveness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,7 @@ export function App(): JSX.Element {
       />
       <main className="content">
         <CardsSection stats={stats} translation={translation} locale={locale} />
-        <ChartsSection data={filteredData} translation={translation} locale={locale} />
+        <ChartsSection data={filteredData} translation={translation} locale={locale} range={range} />
       </main>
       <footer>{translation.footer}</footer>
     </div>

--- a/src/components/Charts/ChartsSection.tsx
+++ b/src/components/Charts/ChartsSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { FC } from 'react';
-import type { DailyEntry } from '../../services/data';
+import type { DailyEntry, RangeKey } from '../../services/data';
 import type { Translation } from '../../i18n';
 import { ChartCard } from './ChartCard';
 import { buildChangeOption, buildDiffOption, buildPriceOption } from './options';
@@ -9,12 +9,22 @@ interface ChartsSectionProps {
   data: DailyEntry[];
   translation: Translation;
   locale: string;
+  range: RangeKey;
 }
 
-export const ChartsSection: FC<ChartsSectionProps> = ({ data, translation, locale }) => {
-  const priceOption = useMemo(() => buildPriceOption(data, translation, locale), [data, translation, locale]);
-  const changeOption = useMemo(() => buildChangeOption(data, translation, locale), [data, translation, locale]);
-  const diffOption = useMemo(() => buildDiffOption(data, translation, locale), [data, translation, locale]);
+export const ChartsSection: FC<ChartsSectionProps> = ({ data, translation, locale, range }) => {
+  const priceOption = useMemo(
+    () => buildPriceOption(data, translation, locale, range),
+    [data, translation, locale, range],
+  );
+  const changeOption = useMemo(
+    () => buildChangeOption(data, translation, locale, range),
+    [data, translation, locale, range],
+  );
+  const diffOption = useMemo(
+    () => buildDiffOption(data, translation, locale, range),
+    [data, translation, locale, range],
+  );
 
   return (
     <section className="chart-grid">

--- a/src/components/Charts/useECharts.ts
+++ b/src/components/Charts/useECharts.ts
@@ -6,6 +6,7 @@ import type { EChartsOption, EChartsType } from 'echarts';
 export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLDivElement | null> {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -18,8 +19,17 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
       chart.resize();
     };
     window.addEventListener('resize', handleResize);
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(() => {
+        chart.resize();
+      });
+      observer.observe(element);
+      resizeObserverRef.current = observer;
+    }
     return () => {
       window.removeEventListener('resize', handleResize);
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
       chart.dispose();
       chartRef.current = null;
     };
@@ -34,6 +44,7 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
       return;
     }
     chartRef.current.setOption(option, true);
+    chartRef.current.resize();
   }, [option]);
 
   return containerRef;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,8 +137,8 @@ h1 {
 .filters-caption {
   font-size: 0.875rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  text-transform: none;
   color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- restore chart tooltips with clearer styling and align axis labels to show hours for the 1D range while keeping daily ticks for longer periods
- keep charts responsive by reacting to container resizes and passing the active range to option builders
- display the “Данные за период” caption in normal case to match the requested style

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d011de98e48326bee879bd6c3dec7c