### PR TITLE
Make brand section span full width

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -108,7 +108,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
-  max-width: min(100%, 760px);
+  width: 100%;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- remove the max-width cap from the brand section so it can stretch across the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02966aac08326886f5f908654248d