### PR TITLE
Set default dashboard range to ALL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function getLocale(language: Language): string {
 
 export function App(): JSX.Element {
   const [language, setLanguage] = useState<Language>(defaultLanguage);
-  const [range, setRange] = useState<RangeKey>('1D');
+  const [range, setRange] = useState<RangeKey>('ALL');
   const [data, setData] = useState<DailyEntry[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize the dashboard range state with ALL so the full dataset is shown on first load
- rely on normalizeRange to clamp the range as data becomes available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d029670d3883269319bee4e8e6c45e