### PR TITLE
Adjust chart tooltip styling

### DIFF
--- a/src/components/Charts/options.ts
+++ b/src/components/Charts/options.ts
@@ -236,7 +236,7 @@ function createCommonChartOptions(locale: string, range: RangeKey): EChartsOptio
     tooltip: {
       trigger: 'axis',
       show: true,
-      backgroundColor: 'rgba(12, 18, 32, 0.96)',
+      backgroundColor: 'rgba(0, 0, 0, 0.8)',
 
       borderColor: 'rgba(255, 255, 255, 0.08)',
       borderWidth: 1,
@@ -247,7 +247,7 @@ function createCommonChartOptions(locale: string, range: RangeKey): EChartsOptio
         'backdrop-filter: blur(18px); border-radius: 12px; box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45); pointer-events: none;',
       axisPointer: {
         type: 'line',
-        lineStyle: { color: colors.accent, width: 1 },
+        lineStyle: { color: 'rgba(255, 255, 255, 0.7)', type: 'dashed', width: 1 },
         label: { show: false },
       },
     },


### PR DESCRIPTION
## Summary
- adjust chart tooltip background to a translucent black to improve contrast
- restyle tooltip axis pointer to use a semi-transparent white dashed line

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02968f38883268071fedf0c3c7cf4