### PR TITLE
Improve localized percent formatting and copy

### DIFF
--- a/src/components/Cards/CardsSection.tsx
+++ b/src/components/Cards/CardsSection.tsx
@@ -38,7 +38,7 @@ export const CardsSection: FC<CardsSectionProps> = ({ stats, translation, locale
         <span
           className={`delta text-[clamp(0.75rem,1vw,0.875rem)] font-semibold text-neutral-400 ${getDeltaClass(stats.vlhx.change)}`}
         >
-          {translation.cards.vlhx.change}: {formatPercent(stats.vlhx.change)}
+          {translation.cards.vlhx.change}: {formatPercent(stats.vlhx.change, locale)}
         </span>
       </article>
       <article
@@ -54,7 +54,7 @@ export const CardsSection: FC<CardsSectionProps> = ({ stats, translation, locale
         <span
           className={`delta text-[clamp(0.75rem,1vw,0.875rem)] font-semibold text-neutral-400 ${getDeltaClass(stats.wbtc.change)}`}
         >
-          {translation.cards.wbtc.change}: {formatPercent(stats.wbtc.change)}
+          {translation.cards.wbtc.change}: {formatPercent(stats.wbtc.change, locale)}
         </span>
       </article>
       <article
@@ -65,7 +65,7 @@ export const CardsSection: FC<CardsSectionProps> = ({ stats, translation, locale
           {translation.cards.spread.label}
         </span>
         <span className={`value text-[clamp(1.75rem,3vw,2.5rem)] font-bold ${getDeltaClass(stats.spread.delta)}`}>
-          {formatPercent(stats.spread.delta)}
+          {formatPercent(stats.spread.delta, locale)}
         </span>
         <span className="delta text-[clamp(0.75rem,1vw,0.875rem)] font-semibold text-neutral-400">
           {translation.cards.spread.note}

--- a/src/components/Charts/options.ts
+++ b/src/components/Charts/options.ts
@@ -424,7 +424,7 @@ export function buildChangeOption(
   option.legend = { ...option.legend, data: [] };
   option.tooltip = {
     ...option.tooltip,
-    formatter: createTooltipFormatter(locale, (val) => formatPercent(val), range),
+    formatter: createTooltipFormatter(locale, (val) => formatPercent(val, locale), range),
   };
   option.yAxis = {
     type: 'value',
@@ -473,7 +473,7 @@ export function buildDiffOption(
   option.legend = { ...option.legend, data: [translation.charts.diff.series.diff] };
   option.tooltip = {
     ...option.tooltip,
-    formatter: createTooltipFormatter(locale, (val) => formatPercent(val), range),
+    formatter: createTooltipFormatter(locale, (val) => formatPercent(val, locale), range),
   };
   option.yAxis = {
     type: 'value',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -18,7 +18,10 @@ export const translations = {
     cards: {
       vlhx: { label: 'VLHXBTC', change: 'Изменение за период' },
       wbtc: { label: 'WBTC', change: 'Изменение за период' },
-      spread: { label: 'Разница в изменении', note: 'Изменение VLHXBTC минус изменение WBTC' },
+      spread: {
+        label: 'Доходность фонда в BTC',
+        note: 'Преимущество VLHXBTC относительно изменения WBTC',
+      },
     },
     charts: {
       price: {

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -265,13 +265,20 @@ export function formatCurrency(value: number | null | undefined, locale: string)
   return formatter.format(value!);
 }
 
-export function formatPercent(value: number | null | undefined, digits = 2): string {
+export function formatPercent(
+  value: number | null | undefined,
+  locale: string,
+  digits = 2,
+): string {
   if (!Number.isFinite(value ?? Number.NaN)) {
     return '--';
   }
-  const formatted = (value as number).toFixed(digits);
-  const prefix = (value as number) > 0 ? '+' : '';
-  return `${prefix}${formatted}%`;
+  const formatter = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    signDisplay: 'exceptZero',
+  });
+  return `${formatter.format(value as number)}%`;
 }
 
 export function computePercentChangeData(filtered: DailyEntry[], key: keyof DailyEntry): PercentChangePoint[] {


### PR DESCRIPTION
## Summary
- update the Russian spread card copy to highlight the fund's BTC performance
- use Intl.NumberFormat in formatPercent with locale-aware signs and decimals
- pass locale through all percent formatting usages for UI and tooltips

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d029730b7483268c99d2493827e8d8