### PR TITLE
Make brand header span full desktop grid width

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -244,7 +244,7 @@ footer {
   }
 
   .brand {
-    grid-column: 1 / 2;
+    grid-column: 1 / -1;
   }
 
   .filters-row {


### PR DESCRIPTION
## Summary
- let the brand section span both columns in the desktop grid so the heading fills the width

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d052dce83c8326aeae3cfb735b051c