### PR TITLE
Add horizontal scroll handling for charts

### DIFF
--- a/src/components/Charts/ChartCard.tsx
+++ b/src/components/Charts/ChartCard.tsx
@@ -12,12 +12,14 @@ export const ChartCard: FC<ChartCardProps> = ({ title, option }) => {
   return (
     <div className="flex flex-col gap-4 rounded-[8px] border border-white/40 px-[clamp(20px,2.5vw,32px)] pb-[clamp(16px,2vw,28px)] pt-[clamp(20px,2.5vw,32px)]">
       <h2 className="m-0 text-[clamp(1.125rem,1.4vw,1.5rem)] font-semibold">{title}</h2>
-      <div
-        ref={chartRef}
-        className="h-[clamp(240px,32vw,420px)] w-full"
-        role="img"
-        aria-label={title}
-      />
+      <div className="max-w-full w-full overflow-x-auto">
+        <div
+          ref={chartRef}
+          className="chart-card__canvas h-[clamp(240px,32vw,420px)] w-full"
+          role="img"
+          aria-label={title}
+        />
+      </div>
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -200,6 +200,10 @@ h1 {
   display: none;
 }
 
+.chart-card__canvas {
+  min-width: 480px;
+}
+
 .delta.positive,
 .value.positive {
   color: #00a0d0;


### PR DESCRIPTION
## Summary
- wrap chart canvas in ChartCard with an overflow container to enable per-chart horizontal scrolling on narrow screens
- add a min-width to the chart canvas to keep the visualization legible when scrolled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d052dd392c832692dab3b4d4f0d94e