### PR TITLE
Improve mobile tooltip interactions

### DIFF
--- a/src/components/Charts/options.ts
+++ b/src/components/Charts/options.ts
@@ -197,6 +197,9 @@ function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+const ENHANCED_TOUCH_TRIGGER =
+  'mousemove|click|touchstart|touchmove' as unknown as TooltipOption['triggerOn'];
+
 const TARGET_LABEL_COUNTS: Record<RangeKey, number> = {
   '1D': 6,
   '1M': 6,
@@ -298,12 +301,14 @@ function createCommonChartOptions(
       padding: 16,
       renderMode: 'html',
       appendToBody: true,
+      triggerOn: ENHANCED_TOUCH_TRIGGER,
       extraCssText:
         'backdrop-filter: blur(18px); border-radius: 12px; box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45); pointer-events: none;',
       axisPointer: {
         type: 'line',
         lineStyle: { color: 'rgba(255, 255, 255, 0.7)', type: 'dashed', width: 1 },
         label: { show: false },
+        snap: true,
       },
     },
     legend: {

--- a/src/components/Charts/useECharts.ts
+++ b/src/components/Charts/useECharts.ts
@@ -111,6 +111,66 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
 
     window.addEventListener('resize', resizeChart);
 
+    const zr = chart.getZr();
+    const getRelativePoint = (event: TouchEvent | MouseEvent | PointerEvent | undefined) => {
+      if (!event) {
+        return null;
+      }
+
+      if ('touches' in event && event.touches.length > 1) {
+        return null;
+      }
+
+      const touch =
+        'touches' in event && event.touches.length > 0
+          ? event.touches[0]
+          : 'changedTouches' in event && event.changedTouches.length > 0
+            ? event.changedTouches[0]
+            : null;
+
+      const pointSource = touch ?? (('clientX' in event && 'clientY' in event) ? event : null);
+      if (!pointSource) {
+        return null;
+      }
+
+      const bounds = element.getBoundingClientRect();
+      return {
+        x: pointSource.clientX - bounds.left,
+        y: pointSource.clientY - bounds.top,
+      };
+    };
+
+    const showTooltip = (event: TouchEvent | MouseEvent | PointerEvent | undefined) => {
+      const point = getRelativePoint(event);
+      if (!point) {
+        return;
+      }
+
+      chart.dispatchAction({ type: 'showTip', x: point.x, y: point.y });
+    };
+
+    const hideTooltip = () => {
+      chart.dispatchAction({ type: 'hideTip' });
+    };
+
+    const handleTouchStart = (params: { event?: TouchEvent | MouseEvent | PointerEvent }) => {
+      showTooltip(params.event);
+    };
+
+    const handleTouchMove = (params: { event?: TouchEvent | MouseEvent | PointerEvent }) => {
+      showTooltip(params.event);
+    };
+
+    const handleTouchEnd = () => {
+      hideTooltip();
+    };
+
+    zr.on('touchstart', handleTouchStart);
+    zr.on('touchmove', handleTouchMove);
+    zr.on('touchend', handleTouchEnd);
+    zr.on('touchcancel', handleTouchEnd);
+    zr.on('globalout', handleTouchEnd);
+
     if (typeof ResizeObserver !== 'undefined') {
       const observer = new ResizeObserver(() => {
         resizeChart();
@@ -134,6 +194,12 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
 
     return () => {
       window.removeEventListener('resize', resizeChart);
+
+      zr.off('touchstart', handleTouchStart);
+      zr.off('touchmove', handleTouchMove);
+      zr.off('touchend', handleTouchEnd);
+      zr.off('touchcancel', handleTouchEnd);
+      zr.off('globalout', handleTouchEnd);
 
       const observer = resizeObserverRef.current;
       if (observer) {


### PR DESCRIPTION
## Summary
- drive tooltip show/hide via touch gestures directly on the chart canvas to ensure reliable mobile behavior
- translate touch coordinates into chart-relative positions and dispatch the proper ECharts actions while guarding against multi-touch gestures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0fc165ae08326a793716c4b9df960