### PR TITLE
Clarify footer data source wording

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,7 +88,30 @@ export function App(): JSX.Element {
         <CardsSection stats={stats} translation={translation} locale={locale} />
         <ChartsSection data={filteredData} translation={translation} locale={locale} range={range} />
       </main>
-      <footer>{translation.footer}</footer>
+      <footer>
+        <p>
+          {translation.footer.blockchainNotice}{' '}
+          {translation.footer.vlhx.prefix}
+          <a
+            href={translation.footer.vlhx.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {translation.footer.vlhx.linkLabel}
+          </a>
+          {translation.footer.vlhx.suffix}{' '}
+          {translation.footer.wbtc.prefix}
+          {translation.footer.wbtc.sources.map((source, index) => (
+            <span key={source.url}>
+              {index > 0 ? translation.footer.wbtc.separator : null}
+              <a href={source.url} target="_blank" rel="noopener noreferrer">
+                {source.label}
+              </a>
+            </span>
+          ))}
+          {translation.footer.wbtc.suffix}
+        </p>
+      </footer>
     </div>
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,7 +3,30 @@ export const translations = {
     title: 'Аналитика Valhalla BTC',
     description:
       'Динамика фонда Valhalla BTC по сравнению с обычным удержанием Bitcoin.',
-    footer: '',
+    footer: {
+      blockchainNotice: 'Метрики формируются на основе on-chain данных сети Arbitrum.',
+      vlhx: {
+        prefix: 'Стоимость VLHXBTC рассчитываем по данным ',
+        linkLabel: 'смарт-контракта Valhalla BTC',
+        url: 'https://arbiscan.io/address/0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9',
+        suffix: '.',
+      },
+      wbtc: {
+        prefix: 'Справочные цены WBTC поступают из ',
+        sources: [
+          {
+            label: 'API CoinGecko',
+            url: 'https://www.coingecko.com/en/coins/wrapped-bitcoin',
+          },
+          {
+            label: 'API CryptoCompare',
+            url: 'https://www.cryptocompare.com/coins/wbtc/overview',
+          },
+        ],
+        separator: ' и ',
+        suffix: ' (резервный источник).',
+      },
+    },
     cta: 'Начать инвестировать',
     filters: {
       '1D': '1Д',
@@ -50,7 +73,30 @@ export const translations = {
     title: 'Valhalla BTC Analytics',
     description:
       'Performance of the Valhalla BTC fund versus holding Bitcoin directly.',
-    footer: '',
+    footer: {
+      blockchainNotice: 'All analytics are derived from on-chain data on Arbitrum.',
+      vlhx: {
+        prefix: 'VLHXBTC valuations are taken directly from the ',
+        linkLabel: 'Valhalla BTC smart contract',
+        url: 'https://arbiscan.io/address/0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9',
+        suffix: '.',
+      },
+      wbtc: {
+        prefix: 'Reference WBTC quotes rely on the ',
+        sources: [
+          {
+            label: 'CoinGecko API',
+            url: 'https://www.coingecko.com/en/coins/wrapped-bitcoin',
+          },
+          {
+            label: 'CryptoCompare API',
+            url: 'https://www.cryptocompare.com/coins/wbtc/overview',
+          },
+        ],
+        separator: ' with ',
+        suffix: ' as the fallback provider.',
+      },
+    },
     cta: 'Start investing',
     filters: {
       '1D': '1D',


### PR DESCRIPTION
## Summary
- update RU and EN footer copy to emphasize on-chain analytics and the Valhalla BTC smart contract source
- clarify that WBTC reference prices come from the CoinGecko API with CryptoCompare as the fallback provider

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0fcc86a948326a280b2fb07d6f4d0