### PR TITLE
Stabilize tooltip positioning and prevent overflow

### DIFF
--- a/src/components/Charts/options.ts
+++ b/src/components/Charts/options.ts
@@ -300,7 +300,6 @@ function createCommonChartOptions(
       borderWidth: 1,
       padding: 16,
       renderMode: 'html',
-      appendToBody: true,
       triggerOn: ENHANCED_TOUCH_TRIGGER,
       extraCssText:
         'backdrop-filter: blur(18px); border-radius: 12px; box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45); pointer-events: none;',

--- a/src/components/Charts/useECharts.ts
+++ b/src/components/Charts/useECharts.ts
@@ -18,8 +18,9 @@ type TooltipPositioner = (
 function createTooltipPositioner(
   getContainer: () => HTMLElement | null,
   getCurrentPoint: () => TooltipPoint | null,
+  getChart: () => EChartsType | null,
 ): TooltipPositioner {
-  return ((point, _params, _dom, _rect, size) => {
+  return ((point, params, _dom, _rect, size) => {
     const effectivePoint = getCurrentPoint() ?? point;
 
     const container = getContainer();
@@ -35,42 +36,189 @@ function createTooltipPositioner(
     const tooltipWidth = size.contentSize[0] ?? 0;
     const tooltipHeight = size.contentSize[1] ?? 0;
 
-    let left = chartLeft + effectivePoint[0] - tooltipWidth / 2;
-    const minLeft = chartLeft + 8;
-    const maxLeft = chartRight - tooltipWidth - 8;
+    const toFiniteNumber = (value: unknown): number | null => {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+      }
+      if (typeof value === 'string') {
+        if (value.trim() === '') {
+          return null;
+        }
+        const numeric = Number(value);
+        if (Number.isFinite(numeric)) {
+          return numeric;
+        }
+        const parsedDate = Date.parse(value);
+        return Number.isFinite(parsedDate) ? parsedDate : null;
+      }
+      return null;
+    };
+
+    type ExtractedPoint = { x: number | null; y: number | null };
+    const ensurePoint = (input: unknown, point: ExtractedPoint): void => {
+      if (input == null) {
+        return;
+      }
+
+      if (Array.isArray(input)) {
+        if (input.length >= 2) {
+          const maybeX = toFiniteNumber(input[0]);
+          const maybeY = toFiniteNumber(input[input.length - 1]);
+          if (maybeX !== null && point.x === null) {
+            point.x = maybeX;
+          }
+          if (maybeY !== null && point.y === null) {
+            point.y = maybeY;
+          }
+        } else if (input.length === 1 && point.y === null) {
+          const maybeY = toFiniteNumber(input[0]);
+          if (maybeY !== null) {
+            point.y = maybeY;
+          }
+        }
+        return;
+      }
+
+      if (typeof input === 'object') {
+        const record = input as Record<string, unknown>;
+        if ('coord' in record) {
+          ensurePoint(record['coord'], point);
+        }
+        if ('value' in record) {
+          ensurePoint(record['value'], point);
+        }
+        if ('x' in record && record['x'] !== undefined && point.x === null) {
+          const maybeX = toFiniteNumber(record['x']);
+          if (maybeX !== null) {
+            point.x = maybeX;
+          }
+        }
+        if ('y' in record && record['y'] !== undefined && point.y === null) {
+          const maybeY = toFiniteNumber(record['y']);
+          if (maybeY !== null) {
+            point.y = maybeY;
+          }
+        }
+        return;
+      }
+
+      if (point.y === null) {
+        const maybeY = toFiniteNumber(input);
+        if (maybeY !== null) {
+          point.y = maybeY;
+        }
+      }
+    };
+
+    const resolveDataPoint = (entry: unknown): { seriesIndex: number | null; point: ExtractedPoint } => {
+      const result: ExtractedPoint = { x: null, y: null };
+      if (!entry || typeof entry !== 'object') {
+        return { seriesIndex: null, point: result };
+      }
+
+      const candidate = entry as Record<string, unknown>;
+      const rawSeriesIndex = candidate['seriesIndex'];
+      const seriesIndex = typeof rawSeriesIndex === 'number' ? rawSeriesIndex : null;
+
+      ensurePoint(candidate['value'], result);
+      ensurePoint(candidate['data'], result);
+
+      if (result.x === null && 'axisValue' in candidate) {
+        const maybeX = toFiniteNumber(candidate['axisValue']);
+        if (maybeX !== null) {
+          result.x = maybeX;
+        }
+      }
+
+      if (result.y === null && 'axisValue' in candidate) {
+        const axisDim = typeof candidate['axisDim'] === 'string' ? candidate['axisDim'] : null;
+        if (axisDim === 'y') {
+          const maybeY = toFiniteNumber(candidate['axisValue']);
+          if (maybeY !== null) {
+            result.y = maybeY;
+          }
+        }
+      }
+
+      return { seriesIndex, point: result };
+    };
+
+    let anchorPointX: number | null = null;
+    let anchorPointY: number | null = null;
+    const chart = getChart();
+    if (chart) {
+      const paramsList = Array.isArray(params) ? params : params ? [params] : [];
+      for (const entry of paramsList) {
+        const { seriesIndex, point: extracted } = resolveDataPoint(entry);
+        if (seriesIndex === null || extracted.x === null || extracted.y === null) {
+          continue;
+        }
+
+        const pixelPoint = chart.convertToPixel({ seriesIndex }, [extracted.x, extracted.y]);
+        if (!Array.isArray(pixelPoint) || pixelPoint.length < 2) {
+          continue;
+        }
+
+        const pixelX = pixelPoint[0];
+        const pixelY = pixelPoint[1];
+        if (!Number.isFinite(pixelX) || !Number.isFinite(pixelY)) {
+          continue;
+        }
+
+        anchorPointX = chartLeft + pixelX;
+        anchorPointY = chartTop + pixelY;
+        break;
+      }
+    }
+
+    const referenceX = anchorPointX ?? chartLeft + effectivePoint[0];
+    let left = referenceX - tooltipWidth / 2;
+    let minLeft = chartLeft + 8;
+    let maxLeft = chartRight - tooltipWidth - 8;
+    if (maxLeft < minLeft) {
+      const center = (chartLeft + chartRight - tooltipWidth) / 2;
+      minLeft = center;
+      maxLeft = center;
+    }
     if (left < minLeft) {
       left = minLeft;
     } else if (left > maxLeft) {
       left = maxLeft;
     }
 
-    const minTop = chartTop + 8;
-    const maxTop = chartBottom - tooltipHeight - 8;
-    const pointerY = chartTop + effectivePoint[1];
+    const pointerY = anchorPointY ?? chartTop + effectivePoint[1];
     const gap = 16;
 
-    const spaceAbove = pointerY - chartTop - tooltipHeight - gap;
-    const spaceBelow = chartBottom - pointerY - tooltipHeight - gap;
-
-    let top = pointerY - tooltipHeight - gap;
-
-    if (spaceAbove < 0) {
-      const belowPointerTop = pointerY + gap;
-      const lackBelow = Math.max(0, -spaceBelow);
-
-      top = belowPointerTop - lackBelow;
-
-      if (lackBelow > 0 && top < minTop) {
-        const remaining = minTop - top;
-        top += remaining / 2;
-      }
+    const rawMinTop = chartTop + 8;
+    const rawMaxTop = chartBottom - tooltipHeight - 8;
+    let minTop = rawMinTop;
+    let maxTop = rawMaxTop;
+    if (rawMaxTop < rawMinTop) {
+      const center = (chartTop + chartBottom - tooltipHeight) / 2;
+      minTop = center;
+      maxTop = center;
     }
 
-    if (top > maxTop) {
-      top = maxTop;
+    const preferAboveTop = pointerY - tooltipHeight - gap;
+    const preferBelowTop = pointerY + gap;
+
+    let top: number;
+
+    if (preferAboveTop >= minTop) {
+      top = preferAboveTop;
+    } else if (preferBelowTop <= maxTop) {
+      const shortageAbove = minTop - preferAboveTop;
+      top = Math.max(minTop, preferBelowTop - shortageAbove);
+    } else {
+      const centeredTop = pointerY - tooltipHeight / 2;
+      top = centeredTop;
     }
+
     if (top < minTop) {
       top = minTop;
+    }
+    if (top > maxTop) {
+      top = maxTop;
     }
 
     return { left, top };
@@ -81,11 +229,13 @@ function enrichTooltipOption(
   tooltip: EChartsOption['tooltip'],
   getContainer: () => HTMLElement | null,
   getCurrentPoint: () => TooltipPoint | null,
+  getChart: () => EChartsType | null,
 ): TooltipConfig {
-  const positioner = createTooltipPositioner(getContainer, getCurrentPoint);
+  const positioner = createTooltipPositioner(getContainer, getCurrentPoint, getChart);
 
   const enhance = (input?: TooltipItem): TooltipItem => {
     const base = { ...(input ?? {}) } as TooltipItem & Record<string, unknown>;
+    const container = getContainer();
 
     if (base.position === undefined) {
       base.position = positioner;
@@ -93,8 +243,11 @@ function enrichTooltipOption(
     if (base.confine === undefined) {
       base.confine = true;
     }
-    if (base.appendToBody === undefined && base.appendTo === undefined) {
-      base.appendToBody = true;
+    if (container && base.appendTo === undefined) {
+      base.appendTo = container;
+    }
+    if (base.appendToBody === undefined || base.appendToBody === true) {
+      base.appendToBody = false;
     }
 
     return base as TooltipItem;
@@ -214,7 +367,13 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
       const constrainedPoint: TooltipPoint = [clampedX, clampedY];
       lastTooltipPointRef.current = constrainedPoint;
 
-      chart.dispatchAction({ type: 'showTip', x: clampedX, y: clampedY });
+      chart.dispatchAction({ type: 'updateAxisPointer', x: clampedX, y: clampedY });
+      chart.dispatchAction({
+        type: 'showTip',
+        x: clampedX,
+        y: clampedY,
+        position: [clampedX, clampedY],
+      });
     };
 
     const hideTooltip = () => {
@@ -358,6 +517,7 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
       option.tooltip,
       () => containerRef.current,
       () => lastTooltipPointRef.current,
+      () => chartRef.current,
     );
     const enrichedOption: EChartsOption = { ...option, tooltip };
 


### PR DESCRIPTION
## Summary
- refine the custom tooltip positioner to clamp placements within the chart bounds while keeping the popup near the anchored point
- keep the tooltip DOM inside the chart container instead of the document body to prevent the page from growing with absolute offsets
- drive both the axis pointer and tooltip with clamped coordinates so touch interactions stay stable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10c163fc083269e0030970e77a320