### PR TITLE
Add favicon and rename period label

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Valhalla BTC vs WBTC Dashboard</title>
   </head>
   <body>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -34,7 +34,7 @@ export const translations = {
       '3M': '3М',
       '6M': '6М',
       '1Y': '1Г',
-      ALL: 'Всё',
+      ALL: 'Все время',
     },
     filtersLabel: 'Выбор периода',
     periodLabel: 'Данные за период',


### PR DESCRIPTION
## Summary
- reference the existing favicon asset from the main HTML entrypoint
- rename the "Всё" period label to "Все время" in the Russian translations

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d167ea5ae0832685dc7a569038f9b1