### PR TITLE
Use relative base path for static hosting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: process.env.GITHUB_PAGES_BASE ?? '/',
+  // Use a relative base path by default so the bundle works both on GitHub Pages
+  // (where it may live under a project subdirectory) and on a root-level
+  // custom domain without requiring extra configuration.
+  base: process.env.GITHUB_PAGES_BASE ?? './',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- adjust the Vite base path to default to a relative URL so the bundle works from custom domains and subdirectories

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17be5b2e08326b2f2bbe1abfc2c72