### PR TITLE
Make GitHub Pages build use relative base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,6 @@ jobs:
         run: npm run daily
       - name: Build static dashboard
         run: npm run build
-        env:
-          GITHUB_PAGES_BASE: "/${{ github.event.repository.name }}/"
       - name: Configure Pages
         uses: actions/configure-pages@v4
       - name: Upload dashboard artifact

--- a/README.md
+++ b/README.md
@@ -52,16 +52,15 @@ By default the exporter uses the public Arbitrum RPC. Override or add fallbacks 
 ```bash
 export ARBITRUM_RPC="https://arb1.arbitrum.io/rpc"
 export ARBITRUM_RPC_FALLBACKS="https://arb1.arbitrum.io/rpc,https://arb-mainnet.g.alchemy.com/v2/demo"
-export GITHUB_PAGES_BASE="/VLHXBTC-dashboard/" # optional for local parity with GitHub Pages
 ```
 
-Create a `.env` or add these variables in GitHub Secrets to use premium endpoints. The deploy workflow automatically injects `GITHUB_PAGES_BASE` so static assets resolve correctly on Pages.
+Create a `.env` or add these variables in GitHub Secrets to use premium endpoints.
 
 ## GitHub Actions
 
 One workflow lives under `.github/workflows/`:
 
-- `deploy.yml` — runs on every push to `main` and once per day at 23:00 UTC. It installs dependencies, executes the collectors via `npm run daily`, builds the static dashboard with the GitHub Pages base path, and uploads the `dist/` artifact for deployment.
+- `deploy.yml` — runs on every push to `main` and once per day at 23:00 UTC. It installs dependencies, executes the collectors via `npm run daily`, builds the static dashboard, and uploads the `dist/` artifact for deployment.
 
 
 ### Publishing to GitHub Pages
@@ -87,7 +86,7 @@ npm run build
 npm run preview
 ```
 
-The dashboard loads CSVs from the repository using relative URLs, so it works automatically on GitHub Pages under a sub-path configured via `import.meta.env.BASE_URL`.
+The dashboard loads CSVs from the repository using relative URLs, so it works automatically on GitHub Pages under a sub-path configured via `import.meta.env.BASE_URL`. The Vite configuration defaults the base path to `./`, keeping asset requests relative for both GitHub Pages and custom domains without extra environment variables.
 
 ### Chart Controls & Cards
 


### PR DESCRIPTION
## Summary
- stop injecting GITHUB_PAGES_BASE during the build so static assets stay relative by default
- document that the Vite configuration already sets a relative base for GitHub Pages and custom domains

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d180df517c8326893a58fd826493b7