### PR TITLE
Display last data update timestamp in footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,16 @@ export function App(): JSX.Element {
   const availableRanges = useMemo(() => getAvailableRanges(data), [data]);
   const filteredData = useMemo(() => filterByRange(range, data), [range, data]);
   const stats = useMemo(() => computeDashboardStats(filteredData), [filteredData]);
+  const lastUpdatedEntry = data.length > 0 ? data[data.length - 1] : undefined;
+  const lastUpdatedDate = lastUpdatedEntry?.date;
+  const lastUpdatedIso = lastUpdatedDate?.toISOString();
+  const lastUpdatedLabel = lastUpdatedDate
+    ? new Intl.DateTimeFormat(locale, {
+        dateStyle: 'long',
+        timeStyle: 'short',
+        timeZone: 'UTC',
+      }).format(lastUpdatedDate)
+    : translation.footer.lastUpdate.unavailable;
 
   const handleToggleLanguage = () => {
     setLanguage((prev) => (prev === 'ru' ? 'en' : 'ru'));
@@ -110,6 +120,14 @@ export function App(): JSX.Element {
             </span>
           ))}
           {translation.footer.wbtc.suffix}
+        </p>
+        <p>
+          {translation.footer.lastUpdate.label}{' '}
+          {lastUpdatedDate ? (
+            <time dateTime={lastUpdatedIso}>{lastUpdatedLabel}</time>
+          ) : (
+            translation.footer.lastUpdate.unavailable
+          )}
         </p>
       </footer>
     </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -26,6 +26,10 @@ export const translations = {
         separator: ' и ',
         suffix: ' (резервный источник).',
       },
+      lastUpdate: {
+        label: 'Последнее обновление данных:',
+        unavailable: 'нет данных',
+      },
     },
     cta: 'Начать инвестировать',
     filters: {
@@ -95,6 +99,10 @@ export const translations = {
         ],
         separator: ' with ',
         suffix: ' as the fallback provider.',
+      },
+      lastUpdate: {
+        label: 'Last data update:',
+        unavailable: 'not available',
       },
     },
     cta: 'Start investing',


### PR DESCRIPTION
## Summary
- add translation strings for a new last update footer label
- compute the most recent dataset date and render it with the footer content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1940ff30c8326ae393058473a97a0