### PR TITLE
Move footer last update into main paragraph

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,15 +119,15 @@ export function App(): JSX.Element {
               </a>
             </span>
           ))}
-          {translation.footer.wbtc.suffix}
-        </p>
-        <p>
-          {translation.footer.lastUpdate.label}{' '}
-          {lastUpdatedDate ? (
-            <time dateTime={lastUpdatedIso}>{lastUpdatedLabel}</time>
-          ) : (
-            translation.footer.lastUpdate.unavailable
-          )}
+          {translation.footer.wbtc.suffix}{' '}
+          <span>
+            {translation.footer.lastUpdate.label}{' '}
+            {lastUpdatedDate ? (
+              <time dateTime={lastUpdatedIso}>{lastUpdatedLabel}</time>
+            ) : (
+              translation.footer.lastUpdate.unavailable
+            )}
+          </span>
         </p>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- move the footer last update message into the main paragraph while keeping translations and spacing intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a3b47a208326b2766568b3751479