### PR TITLE
Replace daily range with 2M preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Automated data exporter and static dashboard that tracks the dHEDGE vault token 
 - Daily BTC/USD and WBTC/USD prices from CoinGecko with ETag-aware caching.
 - Derived NAV vs BTC analytics (ROI in BTC, ROI in USD, alpha vs BTC) exported as CSV.
 - Production-ready GitHub Actions pipeline that refreshes datasets, builds the dashboard, and deploys GitHub Pages without manual commits.
-- Lightweight React + Vite dashboard (ECharts) with preset time range filters (1D/1M/3M/6M/ALL) that reads CSVs directly from the repository.
+- Lightweight React + Vite dashboard (ECharts) with preset time range filters (1M/2M/3M/6M/ALL) that reads CSVs directly from the repository.
 - Robust error handling, exponential backoff for HTTP requests, RPC fallbacks, and data sanity checks.
 
 ## Getting Started
@@ -90,7 +90,7 @@ The dashboard loads CSVs from the repository using relative URLs, so it works au
 
 ### Chart Controls & Cards
 
-- **Time ranges** — presets filter the daily dataset to common windows (1D/1M/3M/6M/ALL).
+- **Time ranges** — presets filter the daily dataset to common windows (1M/2M/3M/6M/ALL).
 - **Summary cards** — show the latest VLHXBTC and WBTC prices, plus the performance spread over the selected window.
 - **Auto refresh** — refreshes data every 10 minutes.
 

--- a/src/components/Charts/options.ts
+++ b/src/components/Charts/options.ts
@@ -98,7 +98,7 @@ function resolveTooltipAxisValue(param: ExtendedCallbackDataParams): string | nu
 }
 
 
-function formatTooltipDate(value: string | number | undefined, locale: string, range: RangeKey): string {
+function formatTooltipDate(value: string | number | undefined, locale: string, _range: RangeKey): string {
   if (value === undefined) {
     return '';
   }
@@ -106,18 +106,12 @@ function formatTooltipDate(value: string | number | undefined, locale: string, r
   if (Number.isNaN(date.getTime())) {
     return '';
   }
-  const options: Intl.DateTimeFormatOptions =
-    range === '1D'
-      ? {
-          day: '2-digit',
-          month: 'long',
-          year: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: false,
-          timeZone: 'UTC',
-        }
-      : { day: '2-digit', month: 'long', year: 'numeric', timeZone: 'UTC' };
+  const options: Intl.DateTimeFormatOptions = {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  };
 
   return new Intl.DateTimeFormat(locale, options).format(date).replace(/\u00a0/g, ' ');
 }
@@ -173,18 +167,6 @@ function formatAxisDate(value: string | number, locale: string): string {
   return formatted.replace(/\u00a0/g, ' ').replace('.', '');
 }
 
-function formatAxisTime(value: string | number, locale: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return '';
-  }
-
-  const formatted =
-    new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' }).format(date);
-
-  return formatted.replace(/\u00a0/g, ' ');
-}
-
 function hexToRgba(hex: string, alpha: number): string {
   const sanitized = hex.replace('#', '');
   if (sanitized.length !== 6) {
@@ -201,8 +183,8 @@ const ENHANCED_TOUCH_TRIGGER =
   'mousemove|click|touchstart|touchmove' as unknown as TooltipOption['triggerOn'];
 
 const TARGET_LABEL_COUNTS: Record<RangeKey, number> = {
-  '1D': 6,
   '1M': 6,
+  '2M': 6,
   '3M': 6,
   '6M': 6,
   '1Y': 6,
@@ -243,8 +225,7 @@ function createCommonChartOptions(
   range: RangeKey,
   seriesData: Array<Array<[number, number]>>,
 ): EChartsOption {
-  const isDailyRange = range === '1D';
-  const minInterval = isDailyRange ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  const minInterval = 24 * 60 * 60 * 1000;
   const bounds = computeTimeBounds(seriesData, minInterval);
   const targetLabels = TARGET_LABEL_COUNTS[range] ?? 6;
   const splitNumber = targetLabels;
@@ -269,8 +250,7 @@ function createCommonChartOptions(
         hideOverlap: true,
         padding: [8, 0, 0, 0],
         interval: 'auto',
-        formatter: (value: string | number) =>
-          (isDailyRange ? formatAxisTime(value, locale) : formatAxisDate(value, locale)),
+        formatter: (value: string | number) => formatAxisDate(value, locale),
       },
       axisTick,
       splitLine: { show: false },

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -33,8 +33,8 @@ export const translations = {
     },
     cta: 'Начать инвестировать',
     filters: {
-      '1D': '1Д',
       '1M': '1М',
+      '2M': '2М',
       '3M': '3М',
       '6M': '6М',
       '1Y': '1Г',
@@ -107,8 +107,8 @@ export const translations = {
     },
     cta: 'Start investing',
     filters: {
-      '1D': '1D',
       '1M': '1M',
+      '2M': '2M',
       '3M': '3M',
       '6M': '6M',
       '1Y': '1Y',

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -1,4 +1,4 @@
-export type RangeKey = '1D' | '1M' | '3M' | '6M' | '1Y' | 'ALL';
+export type RangeKey = '1M' | '2M' | '3M' | '6M' | '1Y' | 'ALL';
 
 interface RangeConfig {
   days?: number;
@@ -6,15 +6,15 @@ interface RangeConfig {
 }
 
 export const RANGE_CONFIG: Record<RangeKey, RangeConfig> = {
-  '1D': { days: 1 },
   '1M': { days: 30 },
+  '2M': { days: 60 },
   '3M': { days: 90 },
   '6M': { days: 180 },
   '1Y': { days: 365 },
   ALL: { all: true },
 };
 
-export const RANGE_ORDER: RangeKey[] = ['1D', '1M', '3M', '6M', '1Y', 'ALL'];
+export const RANGE_ORDER: RangeKey[] = ['1M', '2M', '3M', '6M', '1Y', 'ALL'];
 
 const DATA_SOURCES = {
   nav: 'data/nav_btc_daily.csv',


### PR DESCRIPTION
## Summary
- replace the 1D range option with a new 2M preset across data services and translations
- simplify chart axis formatting after removing the hourly view and add label support for 2M
- update project documentation to list the new time range set

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d230f3c9e08326863862a81dc7dd5a