### PR TITLE
Update Russian description with strategy stats link

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -53,7 +53,21 @@ export const Header: FC<HeaderProps> = ({
       </div>
       <div className="brand">
         <h1>{translation.title}</h1>
-        <p className="description">{translation.description}</p>
+        {typeof translation.description === 'string' ? (
+          <p className="description">{translation.description}</p>
+        ) : (
+          <p className="description">
+            {translation.description.beforeLink}
+            <a
+              href={translation.description.linkUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {translation.description.linkText}
+            </a>
+            {translation.description.afterLink ?? ''}
+          </p>
+        )}
       </div>
       <div className="filters-row">
         <span className="filters-caption">{translation.periodLabel}</span>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,8 +1,14 @@
 export const translations = {
   ru: {
     title: 'Аналитика Valhalla BTC',
-    description:
-      'Динамика фонда Valhalla BTC по сравнению с обычным удержанием Bitcoin.',
+    description: {
+      beforeLink:
+        'Динамика фонда Valhalla BTC по сравнению с обычным удержанием Bitcoin. Статистика по фонду существует за непродолжительное время, для лучшей оценки эффективности рекомендуем смотреть ',
+      linkText: 'статистику самой стратегии',
+      linkUrl:
+        'https://dune.com/gmx-io/v2-lp-dashboard?benchmark_e87f66=&period_e52e23=all-time&pool_efd2e5=gm+arbitrum+BTC%2FUSD+%5BWBTC.b-USDC%5D',
+      afterLink: '.',
+    },
     footer: {
       blockchainNotice: 'Метрики формируются на основе on-chain данных сети Arbitrum и обновляются ежедневно.',
       vlhx: {


### PR DESCRIPTION
## Summary
- extend the Russian dashboard description with guidance to review the broader strategy statistics
- render translated descriptions that provide a contextual link, adding the strategy dashboard URL for the Russian locale

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d234e159208326b2af58a6e7ed5c45