### PR TITLE
Add Valhalla BTC link in Russian description

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -57,7 +57,17 @@ export const Header: FC<HeaderProps> = ({
           <p className="description">{translation.description}</p>
         ) : (
           <p className="description">
-            {translation.description.beforeLink}
+            {translation.description.beforeLink ?? ''}
+            {translation.description.fundLinkText && translation.description.fundLinkUrl ? (
+              <a
+                href={translation.description.fundLinkUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {translation.description.fundLinkText}
+              </a>
+            ) : null}
+            {translation.description.middleText ?? ''}
             <a
               href={translation.description.linkUrl}
               target="_blank"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,8 +2,11 @@ export const translations = {
   ru: {
     title: 'Аналитика Valhalla BTC',
     description: {
-      beforeLink:
-        'Динамика фонда Valhalla BTC по сравнению с обычным удержанием Bitcoin. Статистика по фонду существует непродолжительное время, для лучшей оценки эффективности рекомендуем смотреть ',
+      beforeLink: 'Динамика фонда ',
+      fundLinkText: 'Valhalla BTC',
+      fundLinkUrl: 'https://dhedge.org/vault/0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9',
+      middleText:
+        ' по сравнению с обычным удержанием Bitcoin. Статистика по фонду существует непродолжительное время, для лучшей оценки эффективности рекомендуем смотреть ',
       linkText: 'статистику самой стратегии',
       linkUrl:
         'https://dune.com/gmx-io/v2-lp-dashboard?benchmark_e87f66=&period_e52e23=all-time&pool_efd2e5=gm+arbitrum+BTC%2FUSD+%5BWBTC.b-USDC%5D',


### PR DESCRIPTION
## Summary
- link the first Valhalla BTC mention in the Russian description to the dHEDGE vault page
- update the header description renderer to support the new fund link while keeping styling consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2419d8aac8326aede3c586f8bb5df