### PR TITLE
Add external fund link and widen description layout

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -29,7 +29,7 @@ export const Header: FC<HeaderProps> = ({
   return (
     <header className="top-bar">
       <div className="header-nav">
-        <a className="logo-link" href={baseHref} aria-label="Valhalla home">
+        <a className="logo-link" href="https://vlhx.io" aria-label="Valhalla home">
           <img src={`${baseHref}logo.svg`} alt="Valhalla" />
         </a>
         <div className="header-actions">
@@ -66,6 +66,15 @@ export const Header: FC<HeaderProps> = ({
               {translation.description.linkText}
             </a>
             {translation.description.afterLink ?? ''}
+            {translation.description.additionalLink ? (
+              <a
+                href={translation.description.additionalLink.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {translation.description.additionalLink.text}
+              </a>
+            ) : null}
           </p>
         )}
       </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,7 +7,11 @@ export const translations = {
       linkText: 'статистику самой стратегии',
       linkUrl:
         'https://dune.com/gmx-io/v2-lp-dashboard?benchmark_e87f66=&period_e52e23=all-time&pool_efd2e5=gm+arbitrum+BTC%2FUSD+%5BWBTC.b-USDC%5D',
-      afterLink: '.',
+      afterLink: '. ',
+      additionalLink: {
+        text: 'Подробнее о фонде.',
+        url: 'https://vlhx.io',
+      },
     },
     footer: {
       blockchainNotice: 'Метрики формируются на основе on-chain данных сети Arbitrum и обновляются ежедневно.',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -120,7 +120,7 @@ h1 {
 
 .description {
   margin: 24px 0;
-  max-width: min(100%, 720px);
+  max-width: min(100%, 880px);
   color: #b3b3b3;
   font-size: clamp(1rem, 1.8vw, 1.25rem);
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- add a second external link about the fund to the Russian description copy
- point the header logo to vlhx.io and keep the existing strategy link behaviour
- widen the desktop description text block for improved readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d242fe1bec832683e8dc3b7498672a