### PR TITLE
Use Infura RPC configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         env:
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ARBITRUM_RPC_FALLBACKS: ${{ secrets.ARBITRUM_RPC_FALLBACKS }}
+          INFURA_ARBITRUM_RPC: ${{ secrets.INFURA_ARBITRUM_RPC }}
+          INFURA_ARBITRUM_RPC_FALLBACKS: ${{ secrets.INFURA_ARBITRUM_RPC_FALLBACKS }}
           COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
           HTTP_PROXY: ${{ secrets.HTTP_PROXY }}
           HTTPS_PROXY: ${{ secrets.HTTPS_PROXY }}

--- a/README.md
+++ b/README.md
@@ -46,15 +46,17 @@ All CSV helpers guarantee sorted rows, unique keys, and a trailing newline.
 
 ### Environment Configuration
 
-By default the exporter uses the public Arbitrum RPC. Override or add fallbacks with environment variables:
+The exporter requires a reliable Arbitrum RPC. Configure your Infura endpoint via environment variables:
 
 ```bash
-export ARBITRUM_RPC="https://arb1.arbitrum.io/rpc"
-export ARBITRUM_RPC_FALLBACKS="https://arb1.arbitrum.io/rpc,https://arb-mainnet.g.alchemy.com/v2/demo"
+export ARBITRUM_RPC="https://arbitrum-mainnet.infura.io/v3/<your-key>"
+# optional comma separated fallbacks (e.g. second Infura project)
+export ARBITRUM_RPC_FALLBACKS="https://arbitrum-mainnet.infura.io/v3/<backup-key>"
 export COINMARKETCAP_API_KEY="your-api-key"
 ```
 
-Create a `.env` or add these variables in GitHub Secrets to use premium endpoints.
+You can also set `INFURA_ARBITRUM_RPC` / `INFURA_ARBITRUM_RPC_FALLBACKS` instead of `ARBITRUM_RPC` to avoid exposing the full
+URL in shell history. Add these variables to a `.env` file or GitHub Secrets for CI runs.
 
 ## GitHub Actions
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,4 @@
 export const POOL_LOGIC_ADDRESS = '0xf8fba992f763d8b9a8f47a4c130c1a352c24c6a9';
-const DEFAULT_ARBITRUM_RPC = 'https://arb1.arbitrum.io/rpc';
-const DEFAULT_ARBITRUM_FALLBACKS = [
-  'https://arbitrum.rpc.subquery.network/public',
-  'https://1rpc.io/arb',
-];
 const DEFAULT_START_DATE = '2025-07-23';
 
 function envOrUndefined(key: string): string | undefined {
@@ -15,15 +10,24 @@ function envOrUndefined(key: string): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export const ARBITRUM_RPC = envOrUndefined('ARBITRUM_RPC') ?? DEFAULT_ARBITRUM_RPC;
-const fallbackEnv = envOrUndefined('ARBITRUM_RPC_FALLBACKS');
-const fallbackString =
-  fallbackEnv ?? (ARBITRUM_RPC === DEFAULT_ARBITRUM_RPC ? DEFAULT_ARBITRUM_FALLBACKS.join(',') : '');
-export const ARBITRUM_RPC_FALLBACKS = fallbackString
+function resolveRpcEndpoint(): string {
+  const rpc = envOrUndefined('ARBITRUM_RPC') ?? envOrUndefined('INFURA_ARBITRUM_RPC');
+  if (!rpc) {
+    throw new Error(
+      'Missing Arbitrum RPC endpoint. Set ARBITRUM_RPC or INFURA_ARBITRUM_RPC to a valid Infura URL.'
+    );
+  }
+  return rpc;
+}
 
+export const ARBITRUM_RPC = resolveRpcEndpoint();
+const fallbackEnv =
+  envOrUndefined('ARBITRUM_RPC_FALLBACKS') ?? envOrUndefined('INFURA_ARBITRUM_RPC_FALLBACKS');
+const fallbackString = fallbackEnv ?? '';
+export const ARBITRUM_RPC_FALLBACKS = fallbackString
   .split(',')
   .map((url) => url.trim())
-  .filter((url) => url.length > 0);
+  .filter((url) => url.length > 0 && url !== ARBITRUM_RPC);
 
 export const DAILY_NAV_CSV = 'public/data/nav_tokenprice_usd_daily.csv';
 export const DAILY_WBTC_CSV = 'public/data/wbtc_usd_daily.csv';


### PR DESCRIPTION
## Summary
- require a configured Infura-backed Arbitrum RPC instead of public endpoints
- document the Infura environment variables for local runs and CI
- expose the new Infura secrets to the deployment workflow

## Testing
- ARBITRUM_RPC=https://arbitrum-mainnet.infura.io/v3/test npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d83a8e9f448326aafddf3d754dafd8