### PR TITLE
Ensure NAV exporter backfills missing days

### DIFF
--- a/src/export_token_price_daily.ts
+++ b/src/export_token_price_daily.ts
@@ -37,9 +37,19 @@ function determineDaysToFetch(existing: DayPrice[]): string[] {
     return [];
   }
 
-  const targetDay = isoDay(targetDate);
-  const alreadyRecorded = existing.some((row) => row.day === targetDay);
-  return alreadyRecorded ? [] : [targetDay];
+  const existingDays = new Set(existing.map((row) => row.day));
+  const missing: string[] = [];
+  for (
+    let cursor = new Date(configuredStart.getTime());
+    cursor.getTime() <= targetDate.getTime();
+    cursor = addDays(cursor, 1)
+  ) {
+    const day = isoDay(cursor);
+    if (!existingDays.has(day)) {
+      missing.push(day);
+    }
+  }
+  return missing;
 }
 
 async function fetchTokenPrice(


### PR DESCRIPTION
## Summary
- iterate across the full date range when determining NAV days to fetch
- backfill any missing days from TOKEN_PRICE_START_DATE through yesterday

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dba393938c8326a89d6070e5dc20b8