### PR TITLE
Refine chart resize width detection

### DIFF
--- a/src/components/Charts/useECharts.ts
+++ b/src/components/Charts/useECharts.ts
@@ -95,6 +95,122 @@ const extractPointFromEntry = (entry: unknown): ExtractedPoint => {
   return result;
 };
 
+const parseCssPixelValue = (value: string | null | undefined): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const measureContentWidth = (element: HTMLElement): number | null => {
+  const measure = (node: HTMLElement): number | null => {
+    const clientWidth = node.clientWidth;
+    if (clientWidth > 0) {
+      if (typeof window !== 'undefined' && 'getComputedStyle' in window) {
+        const styles = window.getComputedStyle(node);
+        const paddingLeft = parseCssPixelValue(styles.paddingLeft);
+        const paddingRight = parseCssPixelValue(styles.paddingRight);
+        const contentWidth = clientWidth - paddingLeft - paddingRight;
+        if (contentWidth > 0) {
+          return contentWidth;
+        }
+      } else {
+        return clientWidth;
+      }
+    }
+
+    const rectWidth = node.getBoundingClientRect?.().width ?? 0;
+    if (rectWidth > 0) {
+      if (typeof window !== 'undefined' && 'getComputedStyle' in window) {
+        const styles = window.getComputedStyle(node);
+        const paddingLeft = parseCssPixelValue(styles.paddingLeft);
+        const paddingRight = parseCssPixelValue(styles.paddingRight);
+        const contentWidth = rectWidth - paddingLeft - paddingRight;
+        if (contentWidth > 0) {
+          return contentWidth;
+        }
+      } else {
+        return rectWidth;
+      }
+    }
+
+    return null;
+  };
+
+  let current: HTMLElement | null = element;
+  while (current) {
+    const measured = measure(current);
+    if (measured && measured > 0) {
+      return measured;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
+};
+
+const resolveWidthHint = (dom: HTMLElement, hint: number | null | undefined): number | null => {
+  if (hint && hint > 0) {
+    return hint;
+  }
+
+  const parent = dom.parentElement;
+  if (parent) {
+    const parentWidth = measureContentWidth(parent);
+    if (parentWidth && parentWidth > 0) {
+      return parentWidth;
+    }
+  }
+
+  return measureContentWidth(dom);
+};
+
+const resizeChartToContainer = (
+  chart: EChartsType | null,
+  widthHint?: number | null,
+): void => {
+  if (!chart) {
+    return;
+  }
+
+  const dom = chart.getDom?.();
+
+  if (!(dom instanceof HTMLElement)) {
+    chart.resize();
+    return;
+  }
+
+  dom.style.maxWidth = '100%';
+  dom.style.removeProperty('height');
+
+  const executeResize = () => {
+    const previousWidth = dom.style.width;
+    dom.style.removeProperty('width');
+
+    const resolvedWidth = resolveWidthHint(dom, widthHint);
+
+    if (resolvedWidth && resolvedWidth > 0) {
+      const normalizedWidth = Math.max(0, Math.round(resolvedWidth));
+      dom.style.width = `${normalizedWidth}px`;
+      chart.resize({ width: normalizedWidth });
+      return;
+    }
+
+    if (previousWidth) {
+      dom.style.width = previousWidth;
+    }
+    chart.resize();
+  };
+
+  if (typeof window !== 'undefined' && 'requestAnimationFrame' in window) {
+    window.requestAnimationFrame(executeResize);
+  } else {
+    executeResize();
+  }
+};
+
 type TooltipPositioner = (
   point: TooltipPoint,
   params: unknown,
@@ -339,11 +455,15 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
     const chart = echarts.init(element);
     chartRef.current = chart;
 
-    const resizeChart = () => {
-      chart.resize({ width: element.clientWidth, height: element.clientHeight });
+    const resizeChart = (widthHint?: number | null) => {
+      resizeChartToContainer(chart, widthHint);
     };
 
-    window.addEventListener('resize', resizeChart);
+    const handleWindowResize = () => {
+      resizeChart();
+    };
+
+    window.addEventListener('resize', handleWindowResize);
 
     const zr = chart.getZr();
 
@@ -657,8 +777,25 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
 
 
     if (typeof ResizeObserver !== 'undefined') {
-      const observer = new ResizeObserver(() => {
-        resizeChart();
+      const observer = new ResizeObserver((entries) => {
+        let widthHint: number | null = null;
+
+        for (const entry of entries) {
+          const target = entry.target;
+          if (!(target instanceof HTMLElement)) {
+            continue;
+          }
+          if (target === element) {
+            continue;
+          }
+
+          const candidateWidth = entry.contentRect?.width ?? 0;
+          if (candidateWidth > 0) {
+            widthHint = widthHint === null ? candidateWidth : Math.min(widthHint, candidateWidth);
+          }
+        }
+
+        resizeChart(widthHint);
       });
 
       const observed: HTMLElement[] = [];
@@ -678,7 +815,7 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
     resizeChart();
 
     return () => {
-      window.removeEventListener('resize', resizeChart);
+      window.removeEventListener('resize', handleWindowResize);
 
 
       zr.off('touchstart', handlePointerActivate);
@@ -740,12 +877,7 @@ export function useECharts(option: EChartsOption | null): MutableRefObject<HTMLD
     const enrichedOption: EChartsOption = { ...option, tooltip };
 
     chart.setOption(enrichedOption, true);
-    const element = containerRef.current;
-    if (element) {
-      chart.resize({ width: element.clientWidth, height: element.clientHeight });
-    } else {
-      chart.resize();
-    }
+    resizeChartToContainer(chart);
 
   }, [option]);
 


### PR DESCRIPTION
## Summary
- measure chart container widths via reusable helpers that strip parent padding and honour resize observer hints
- forward width hints from resize observers and window events so echarts dom nodes stay aligned with their cards after viewport changes
- keep chart max-width at 100% while recalculating pixel widths through requestAnimationFrame to avoid persistent overflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbb51f30888326ae5d2d7cd55a3cb7