### PR TITLE
Handle missing RPC configuration during build

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,13 +43,15 @@ function resolveRpcEndpoint(): string {
 
   const rpc = explicitRpc ?? infuraRpc;
 
-  if (!rpc) {
-    throw new Error(
-      'Missing Arbitrum RPC endpoint. Provide ARBITRUM_RPC or set an Infura key/URL.'
-    );
+  if (rpc) {
+    return rpc;
   }
 
-  return rpc;
+  // Fall back to the public Arbitrum RPC so that static builds can
+  // succeed even when no environment variables are configured. The
+  // public endpoint has lower rate limits, but it is sufficient for the
+  // build step where we just need to render the static site.
+  return 'https://arb1.arbitrum.io/rpc';
 }
 
 export const ARBITRUM_RPC = resolveRpcEndpoint();


### PR DESCRIPTION
## Summary
- default to the public Arbitrum RPC endpoint when no environment variables are set so static builds can complete
- treat network connectivity failures when fetching WBTC prices as non-fatal so the build pipeline can continue

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe047cf608326a7523978e637e206