### PR TITLE
Allow dataset commits on push workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           NO_PROXY: ${{ secrets.NO_PROXY }}
           TOKEN_PRICE_START_DATE: ${{ secrets.TOKEN_PRICE_START_DATE }}
       - name: Commit refreshed datasets
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -48,7 +48,7 @@ jobs:
           fi
           git commit -m "chore: refresh datasets [skip ci]"
       - name: Push refreshed datasets
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || github.event_name == 'push'
         run: git push
       - name: Build static dashboard
         run: npm run build


### PR DESCRIPTION
## Summary
- allow the dataset refresh workflow to commit and push updates during push-triggered runs in addition to scheduled runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbee7a83308326b5b2dec6b14abed6